### PR TITLE
fix: transform Flow files with no imports

### DIFF
--- a/.grit/patterns/FlowToTypeScript.md
+++ b/.grit/patterns/FlowToTypeScript.md
@@ -3,7 +3,10 @@
 Converts Flow type annotations to TypeScript type annotations on a best-effort basis.
 
 ```grit
+language js
+
 Program(and {
+  contains CommentLine(value = "@flow")
   maybe [
     maybe bubble or  {
       ImportDeclaration(leadingComments = [CommentBlock($c), ...]),
@@ -11,7 +14,7 @@ Program(and {
     } as $node => raw("/*" + $c + "*/\n" + unparse($node))
     some bubble or { ImportDeclaration(), ExportDeclaration() } as $node => raw(unparse($node))
   ]
-  contains bubble TypeAnnotation() as $node => raw(unparse($node))
+  maybe contains bubble TypeAnnotation() as $node => raw(unparse($node))
 })
 ```
 

--- a/.grit/patterns/FlowToTypeScript.md
+++ b/.grit/patterns/FlowToTypeScript.md
@@ -4,14 +4,14 @@ Converts Flow type annotations to TypeScript type annotations on a best-effort b
 
 ```grit
 Program(and {
-  [
+  maybe [
     maybe bubble or  {
       ImportDeclaration(leadingComments = [CommentBlock($c), ...]),
       ExportDeclaration(leadingComments = [CommentBlock($c), ...])
     } as $node => raw("/*" + $c + "*/\n" + unparse($node))
-    some bubble or { ImportDeclaration(), ExportDeclaration() } as $node => raw(unparse($node)) 
+    some bubble or { ImportDeclaration(), ExportDeclaration() } as $node => raw(unparse($node))
   ]
-  maybe contains bubble TypeAnnotation() as $node => raw(unparse($node))
+  contains bubble TypeAnnotation() as $node => raw(unparse($node))
 })
 ```
 
@@ -58,42 +58,52 @@ export default checkAnimalBreed;
 
 ```js
 //@flow
-import type { Foo, Sam } from '../types';
-import type { Dog } from './animals';
+import type { Foo, Sam } from "../types";
+import type { Dog } from "./animals";
 export type DogBreed = {
   name: string,
-}
-const animal = 'dog';
+};
+const animal = "dog";
 
 function checkDog(dog: Dog): string {
   return dog.name;
 }
 
-function multiLine({
-  foo,
-  bar
-}: {
-  foo: string,
-  bar: string
-  }) {
+function multiLine({ foo, bar }: { foo: string, bar: string }) {
   console.log(foo);
 }
 
-const checkAnimalBreed = async (
-  {
-    breed,
-    dog
-  }: {
-      breed: DogBreed,
-      dog: Dog,
-    }
-): boolean => {
-    return dog.breed === breed.name;
+const checkAnimalBreed = async ({
+  breed,
+  dog,
+}: {
+  breed: DogBreed,
+  dog: Dog,
+}): boolean => {
+  return dog.breed === breed.name;
 };
 
 const checkBoolean = async (): boolean => {
-    return false;
+  return false;
 };
 
 export default checkAnimalBreed;
+```
+
+## Transform files with no imports
+
+```js
+//@flow
+
+const checkBoolean = async () /*: boolean */ => {
+  return false;
+};
+```
+
+```ts
+//@flow
+
+const checkBoolean = async (): boolean => {
+  return false;
+};
 ```


### PR DESCRIPTION
It's probably a safer bet to assume all Flow files contain at least one type annotation, but we ideally should match if *either* condition is true without short-circuiting.