### PR TITLE
chore: move studio sample to standard library

### DIFF
--- a/.grit/patterns/ES6ArrowFunctions.md
+++ b/.grit/patterns/ES6ArrowFunctions.md
@@ -15,7 +15,7 @@ To see how it works, follow the tutorial.
 */
 or {
   `function ($args) { $body }` => `($args) => { $body }` where {
-    body <: not contains {
+    $body <: not contains {
       or { `this`, `arguments` }
     } until `function $_($_) { $_ }`
   }


### PR DESCRIPTION
We should pull the default samples from the standard library just like any other preset.