### PR TITLE
chore: add comma in pattern lists

### DIFF
--- a/.grit/patterns/AddTypeScriptTypes.md
+++ b/.grit/patterns/AddTypeScriptTypes.md
@@ -9,13 +9,13 @@ Copy the actual pattern into ../workflows/js-to-ts.ts as well. -->
 language js
 
 or {
-    ClassMethod(params=$params)
+    ClassMethod(params=$params),
     FunctionDeclaration(params=$params)
 } where {
     $params <: contains bubble {
         or {
             Identifier(name="$TSFixMe") => $type,
-            TSAnyKeyword() as $any => $type
+            TSAnyKeyword() as $any => $type,
             Identifier(typeAnnotation=null => $type)
         } where {
             $type = guess(codePrefix="// fix TypeScript type declarations", fallback="any", stop=["function"])

--- a/.grit/patterns/ChaiToJest.md
+++ b/.grit/patterns/ChaiToJest.md
@@ -12,60 +12,60 @@ tags: #migration, #js
 or {
     // pure chai -- assert
 
-    `assert.match($s, $p, $_)` => `expect($s).toMatch($p)`
-    `assert.isFalse($x, $_)` => `expect($x).toBe(false)`
-    `assert.isTrue($x, $_)` => `expect($x).toBe(true)`
-    `assert.isNull($x, $_)` => `expect($x).toBe(null)`
-    `assert.toBe($x, $a, $_)` => `expect($x).toBe($a)`
-    `assert.isDefined($x, $_)` => `expect($x).toBeDefined()`
-    `assert.include($haystack, $needle, $_)` => `expect($haystack).toContain($needle)`
-    `assert.strictEqual($a, $b, $_)` => `expect($a).toBe($b)`
-    `assert.deepEqual($a, $b, $_)` => `expect($a).toEqual($b)`
-    `assert.equal($a, $b, $_)` => `expect($a).toEqual($b)`
-    `assert($x, $_)` =>  `expect($x).toBeTruthy()`
+    `assert.match($s, $p, $_)` => `expect($s).toMatch($p)`,
+    `assert.isFalse($x, $_)` => `expect($x).toBe(false)`,
+    `assert.isTrue($x, $_)` => `expect($x).toBe(true)`,
+    `assert.isNull($x, $_)` => `expect($x).toBe(null)`,
+    `assert.toBe($x, $a, $_)` => `expect($x).toBe($a)`,
+    `assert.isDefined($x, $_)` => `expect($x).toBeDefined()`,
+    `assert.include($haystack, $needle, $_)` => `expect($haystack).toContain($needle)`,
+    `assert.strictEqual($a, $b, $_)` => `expect($a).toBe($b)`,
+    `assert.deepEqual($a, $b, $_)` => `expect($a).toEqual($b)`,
+    `assert.equal($a, $b, $_)` => `expect($a).toEqual($b)`,
+    `assert($x, $_)` =>  `expect($x).toBeTruthy()`,
 
     or {
-      `$xtobe.deep.equal($v)` => `$x.toEqual($v)`
-      `$xtobe.equal($v)` => `$x.toBe($v)` // this is wrong in jest-codemods
-      `$xtobe.equals($v)` => `$x.toBe($v)`
-      `$xtobe.eql($v)` => `$x.toEqual($v)`
-      `$xtobe.eq($v)` => `$x.toEqual($v)`
-      `$xtobe.greaterThan($n)` => `$x.toBeGreaterThan($n)`
-      `$xtobe.null` => `$x.toBeNull()`
-      `$xtobe.be($v)` => `$x.toBe($v)` // leave it with .be to avoid false positives
-      `$xtobe.true` => `$x.toBe(true)`
-      `$xtobe.false` => `$x.toBe(false)`
-      `$xtobe.exist` => `$x.toEqual(expect.anything())`
-      `$xtobe.undefined` => `$x.toBeUndefined()`
-      `$xtobe.empty` => `$x.toHaveLength(0)`
-      `$xtobe.a('function')` => `$x.toBeInstanceOf(Function)`
+      `$xtobe.deep.equal($v)` => `$x.toEqual($v)`,
+      `$xtobe.equal($v)` => `$x.toBe($v)`, // this is wrong in jest-codemods
+      `$xtobe.equals($v)` => `$x.toBe($v)`,
+      `$xtobe.eql($v)` => `$x.toEqual($v)`,
+      `$xtobe.eq($v)` => `$x.toEqual($v)`,
+      `$xtobe.greaterThan($n)` => `$x.toBeGreaterThan($n)`,
+      `$xtobe.null` => `$x.toBeNull()`,
+      `$xtobe.be($v)` => `$x.toBe($v)`, // leave it with .be to avoid false positives
+      `$xtobe.true` => `$x.toBe(true)`,
+      `$xtobe.false` => `$x.toBe(false)`,
+      `$xtobe.exist` => `$x.toEqual(expect.anything())`,
+      `$xtobe.undefined` => `$x.toBeUndefined()`,
+      `$xtobe.empty` => `$x.toHaveLength(0)`,
+      `$xtobe.a('function')` => `$x.toBeInstanceOf(Function)`,
       `$xtobe.instanceOf($t)` => `$x.toBeInstanceOf($t)`
     } where {
       $xtobe <: or { `$x.to.be`, `$x.to`, $x }
-    }
+    },
 
     `$xtobe.object` => `expect(typeof $o === 'object').toBeTruthy()` where {
-      $xtobe <: or { `$x.to.be`, `$x.to`, $x }
+      $xtobe <: or { `$x.to.be`, `$x.to`, $x },
       $x <: `expect($o)`
-    }
+    },
 
     // tos
     or {
       or {
-        `$xto.deep.$include($v, $_)` => `$x.toMatchObject($v)`
-        `$xto.$include($e, $_)` => `$x.toMatchObject($e)` where $e <: semantic ObjectExpression`{ $_ }`
+        `$xto.deep.$include($v, $_)` => `$x.toMatchObject($v)`,
+        `$xto.$include($e, $_)` => `$x.toMatchObject($e)` where $e <: semantic ObjectExpression`{ $_ }`,
         `$xto.$include($e, $_)` => `$x.toContain($e)`
-      } where $include <: or { `include`, `includes`, `contain`, `contains` }
+      } where $include <: or { `include`, `includes`, `contain`, `contains` },
 
-      `$xto.match($p, $_)` => `$x.toMatch($p)` // leave it with to.match to avoid false positives
+      `$xto.match($p, $_)` => `$x.toMatch($p)`, // leave it with to.match to avoid false positives
       or {
-        `$xto.$h.length($n)` => `$x.toHaveLength($n)`
-        `$xto.$h.lengthOf($n)` => `$x.toHaveLength($n)`
-        `$xto.$h.property($p)` => `$x.toHaveProperty($p)`
+        `$xto.$h.length($n)` => `$x.toHaveLength($n)`,
+        `$xto.$h.lengthOf($n)` => `$x.toHaveLength($n)`,
+        `$xto.$h.property($p)` => `$x.toHaveProperty($p)`,
         `$xto.$h.keys($oneKey)` => `$x.toHaveProperty($oneKey)` where $oneKey <: not or { `[ $_ ]`, [ ... ] }
       } where $h <: or { `have` , `has` }
     } where {
-      $xto <: or { `$x.to`, $x }
+      $xto <: or { `$x.to`, $x },
       $x <: or { `expect($o)`, `expect($o).not` }
     }
 }

--- a/.grit/patterns/ConvertNegativeZeroEqualityCheckToObjectIs.md
+++ b/.grit/patterns/ConvertNegativeZeroEqualityCheckToObjectIs.md
@@ -12,7 +12,7 @@ tags: #SD
 
 ```grit
 or {
-  or { `$x == -0` , `$x === -0` } => `Object.is($x, -0)`
+  or { `$x == -0` , `$x === -0` } => `Object.is($x, -0)`,
   or { `$x != -0` , `$x !== -0` } => `!Object.is($x, -0)`
 }
 ```

--- a/.grit/patterns/ConvertPureComponentToComponent.md
+++ b/.grit/patterns/ConvertPureComponentToComponent.md
@@ -13,7 +13,7 @@ tags: #SD, #React
 
 ```grit
 `class $name extends $extends { $body }` where {
-  $extends <: contains `PureComponent` => `Component`
+  $extends <: contains `PureComponent` => `Component`,
   $body <: some `shouldComponentUpdate($_) { $_ }`
 }
 ```

--- a/.grit/patterns/ES6ArrowFunctions.md
+++ b/.grit/patterns/ES6ArrowFunctions.md
@@ -18,7 +18,7 @@ or {
     $body <: not contains {
       or { `this`, `arguments` }
     } until `function $_($_) { $_ }`
-  }
+  },
   `($args) => { return $value }` => `($args) => $value`
 }
 ```

--- a/.grit/patterns/ES6Exports.md
+++ b/.grit/patterns/ES6Exports.md
@@ -14,21 +14,21 @@ or {
         `module.exports = { $vals }` where {
             // it's only safe to remove the overall export if every property is individually exported
             $vals <: some let($key, $name, $val, $match, $prop) ObjectProperty(key=$key, value=$name) as $prop => . where {
-                $name <: Identifier()
-                $exportedVals = [... $exportedVals, $prop]
+                $name <: Identifier(),
+                $exportedVals = [... $exportedVals, $prop],
                 $program <: contains or {
-                    `const $name = $val`
-                    `let $name = $val`
-                    `var $name = $val`
-                    `const $name = $val`
+                    `const $name = $val`,
+                    `let $name = $val`,
+                    `var $name = $val`,
+                    `const $name = $val`,
                     FunctionDeclaration(id=$name)
                 } as $match => ExportNamedDeclaration(declaration=$match)
             }
-        }
+        },
         maybe `module.exports = { $vals }` => . where $vals <: $exportedVals
-    }
+    },
     // handle other default exports
-    `module.exports = $export` => `export default $export`
+    `module.exports = $export` => `export default $export`,
     // Handle individually named exports
     `module.exports.$name = $export` => `export const $name = $export`
 }

--- a/.grit/patterns/ES6Imports.md
+++ b/.grit/patterns/ES6Imports.md
@@ -14,9 +14,9 @@ or {
         $imports <: some bubble($transformed) {ObjectProperty(key=$key, value=$val) where {
             $transformed = [...$transformed, `$key as $val`]
         } }
-    }
-    `const $import = require($source).default` => `import $import from "$source"`
-    `const $import = require($source).$foo` => `import { $foo as $import } from "$source"`
+    },
+    `const $import = require($source).default` => `import $import from "$source"`,
+    `const $import = require($source).$foo` => `import { $foo as $import } from "$source"`,
     `const $import = require($source)` => `import $import from "$source"` // this relies on healing for correctness
 }
 ```

--- a/.grit/patterns/EnforceStrictEqualityCheck.md
+++ b/.grit/patterns/EnforceStrictEqualityCheck.md
@@ -12,7 +12,7 @@ tags: #fix, #SD
 
 ```grit
 or {
-  `$x == $y` => `$x === $y`
+  `$x == $y` => `$x === $y`,
   `$x != $y` => `$x !== $y`
 } where {
   $y <: not `null`

--- a/.grit/patterns/ExplicitTypeConversion.md
+++ b/.grit/patterns/ExplicitTypeConversion.md
@@ -10,7 +10,7 @@ tags: #SE
 
 ```grit
 or {
-  or {`+$value`, `1 * $value`} => `Number($value)`
+  or {`+$value`, `1 * $value`} => `Number($value)`,
   or { `"" + $value`, `$value + ""`, `'' + $value`, `$value + ''` } => `String($value)`
 }
 ```

--- a/.grit/patterns/FixJSXFiles.md
+++ b/.grit/patterns/FixJSXFiles.md
@@ -6,11 +6,11 @@ Files containing JSX should have a .jsx extension.
 language js
 
 File(name=$name, program=$body) where {
-    $body <: contains JSXElement()
+    $body <: contains JSXElement(),
     $name <: or {
       r"(.+).js" where {
         $name => replaceAll($name, ".js", ".jsx")
-      }
+      },
       r"(.+).ts" where {
         $name => replaceAll($name, ".ts", ".tsx")
       }

--- a/.grit/patterns/FlowToTypeScript.md
+++ b/.grit/patterns/FlowToTypeScript.md
@@ -4,17 +4,17 @@ Converts Flow type annotations to TypeScript type annotations on a best-effort b
 
 ```grit
 Program(and {
-  contains CommentLine(value = r" *@flow")
+  contains CommentLine(value = r" *@flow"),
   maybe [
     maybe bubble or  {
       ImportDeclaration(leadingComments = [CommentBlock($c), ...]),
       ExportDeclaration(leadingComments = [CommentBlock($c), ...])
-    } as $node => raw("/*" + $c + "*/\n" + unparse($node))
+    } as $node => raw("/*" + $c + "*/\n" + unparse($node)),
     some bubble or { ImportDeclaration(), ExportDeclaration() } as $node => raw(unparse($node))
-  ]
-  maybe contains bubble TypeAnnotation() as $node => raw(unparse($node))
+  ],
+  maybe contains bubble TypeAnnotation() as $node => raw(unparse($node)),
   maybe contains bubble CommentBlock(value = $comment) where {
-    $comment <: r"(?s).*@returns.*import\\('(.*)'\\).([^<]*).*"($lib, $type)
+    $comment <: r"(?s).*@returns.*import\\('(.*)'\\).([^<]*).*"($lib, $type),
     ensureImportFrom(Identifier(name = $type), $lib)
   }
 })

--- a/.grit/patterns/ForDirection.md
+++ b/.grit/patterns/ForDirection.md
@@ -11,11 +11,11 @@ tags: #bug, #fix, #good
 ```grit
 or {
   `for ($_; $test; $counter) $_` where {
-      $test <: contains or { `$x < $_` , `$x <= $_` , `$_ > $x` , `$_ >= $x`}
+      $test <: contains or { `$x < $_` , `$x <= $_` , `$_ > $x` , `$_ >= $x`},
       $counter <: contains { `$x--` => `$x++`}
-  }
+  },
   `for ($_; $test; $counter) $_` where {
-      $test <: contains or { `$x > $_` , `$x >= $_` , `$_ < $x` , `$_ <= $x`}
+      $test <: contains or { `$x > $_` , `$x >= $_` , `$_ < $x` , `$_ <= $x`},
       $counter <: contains { `$x++` => Expression`$x--` }
   }
 }

--- a/.grit/patterns/IndexOfToIncludes.md
+++ b/.grit/patterns/IndexOfToIncludes.md
@@ -10,7 +10,7 @@ tags: #ES7, #SE
 
 ```grit
 or {
-  or {`$indexOf == -1` , `$indexOf === -1`} => `!$var.includes($key)`
+  or {`$indexOf == -1` , `$indexOf === -1`} => `!$var.includes($key)`,
   or { `~$indexOf` , `$indexOf != -1` , `$indexOf !== -1` } => `$var.includes($key)`
 } where $indexOf <: or { `$var.indexOf($key)` , `$var.lastIndexOf($key)` }
 

--- a/.grit/patterns/JestArrayContaining.md
+++ b/.grit/patterns/JestArrayContaining.md
@@ -5,23 +5,23 @@ so multiple statements are not required.
 
 ```grit
 `it($body)` where {
-    $all = []
-    $containing = []
+    $all = [],
+    $containing = [],
     
     // Collect all arrayContaining
     $body <: contains {
         bubble($value, $containing, $last, $all) `expect($value).toEqual(expect.arrayContaining([$x]))` as $current where {
-            $all = [...$all, $current]
-            $last = $current
+            $all = [...$all, $current],
+            $last = $current,
             $containing = [...$containing, $x]
         }
-    }
+    },
 
     // Make the last one contain all of them
-    $last => `expect($value).toEqual(expect.arrayContaining([$containing]))`
+    $last => `expect($value).toEqual(expect.arrayContaining([$containing]))`,
 
     // Remove the others
-    $others = without($all, [$last])
+    $others = without($all, [$last]),
     $others <: some bubble $expect => .
 }
 ```

--- a/.grit/patterns/KnockoutToReact.md
+++ b/.grit/patterns/KnockoutToReact.md
@@ -11,14 +11,14 @@ tags: #react, #migration, #complex, #knockout, #framework
 ```grit
 or {
   `$vm = function($args) { $body }` where {
-    $vm <: `ViewModel` => `ViewComponent`
-    $args => `props`
+    $vm <: `ViewModel` => `ViewComponent`,
+    $args => `props`,
     $body <: maybe contains bubble or {
       `this.$name = ko.observable($original)` => `const [$name, $setter] = useState(props.$name)` where {
-        $capitalized = capitalize($name)
-        $setter = s"set${capitalized}"
+        $capitalized = capitalize($name),
+        $setter = s"set${capitalized}",
         ensureImportFrom(`useState`, "react")
-      }
+      },
       `this.$name = ko.computed($func, $_)` => `const name = useMemo($func)` where {
         $func <: maybe contains bubble { `this.$name()` => `$name`}
       }

--- a/.grit/patterns/NoAnonymousDefaultExport.md
+++ b/.grit/patterns/NoAnonymousDefaultExport.md
@@ -12,7 +12,7 @@ tags: #syntax
 or {
   `export default function $name($args) { $body }` where {
     $name <: null => `main`
-  }
+  },
   `export default $f` => [`const main = $f`, `export default main`] where {
     $f <: `($args) => { $body }`
   }

--- a/.grit/patterns/NoArrayConstructor.md
+++ b/.grit/patterns/NoArrayConstructor.md
@@ -12,7 +12,7 @@ tags: #fix
 
 ```grit
 or {
-  `new Array($args)` => `[$args]`
+  `new Array($args)` => `[$args]`,
   `Array($args)` => `[$args]`
 } where {
   $args <: [$_, $_, ...]

--- a/.grit/patterns/NoAsyncPromiseExecutor.md
+++ b/.grit/patterns/NoAsyncPromiseExecutor.md
@@ -13,12 +13,12 @@ tags: #fix, #bug
 ```grit
 or {
   `new Promise($promise)` where {
-    $promise <: contains { `async $args => $body` => `$args => $body`}
+    $promise <: contains { `async $args => $body` => `$args => $body`},
     $body <: not contains { AwaitExpression() }
-  }
+  },
 
   `new Promise(async ($resolve, $reject) => $body)` => `(async () => $body)()` where {
-    $body <: contains { AwaitExpression() }
+    $body <: contains { AwaitExpression() },
     $body <: contains bubble or { `resolve($a)` =>  `return $a;` , `reject($a)`  =>  `throw $a;` }
   }
 }

--- a/.grit/patterns/NoBitwise.md
+++ b/.grit/patterns/NoBitwise.md
@@ -8,7 +8,7 @@ Bitwise operators `&` or `|` are often used by mistake instead of `&&` or `||`, 
 
 ```grit
 or {
-  `$x & $y` => `$x && $y`
+  `$x & $y` => `$x && $y`,
   `$x | $y` => `$x || $y`
 }
 ```

--- a/.grit/patterns/NoCaller.md
+++ b/.grit/patterns/NoCaller.md
@@ -14,7 +14,7 @@ tags: #fix
 or {
   `function $name($_) { $body }` where {
     $body <: contains let($arg) { `arguments.callee($arg)` => `$name($arg)`}
-  }
+  },
 
   `function $name($_){ $body }` where {
     $body <: contains  { `arguments.caller` => `$name.caller`}

--- a/.grit/patterns/NoIterator.md
+++ b/.grit/patterns/NoIterator.md
@@ -10,11 +10,11 @@ tags: #good
 
 ```grit
 or {
-  `$obj.prototype.__iterator__` => `$obj._iterator_`
-  `$obj.prototype["__iterator__"]` => `$obj._iterator_`
-  `$obj.prototype['__iterator__']` => `$obj._iterator_`
-  `$obj.__iterator__` => `$obj._iterator_`
-  `$obj["__iterator__"]` => `$obj._iterator_`
+  `$obj.prototype.__iterator__` => `$obj._iterator_`,
+  `$obj.prototype["__iterator__"]` => `$obj._iterator_`,
+  `$obj.prototype['__iterator__']` => `$obj._iterator_`,
+  `$obj.__iterator__` => `$obj._iterator_`,
+  `$obj["__iterator__"]` => `$obj._iterator_`,
   `$obj['__iterator__']` => `$obj._iterator_`
 }
 ```

--- a/.grit/patterns/NoNewObject.md
+++ b/.grit/patterns/NoNewObject.md
@@ -12,7 +12,7 @@ tags: #good, #syntax
 
 ```grit
 or {
-  `new Object()` => `{}`
+  `new Object()` => `{}`,
   `new Object` => `{}`
 }
 ```

--- a/.grit/patterns/NoNewSymbol.md
+++ b/.grit/patterns/NoNewSymbol.md
@@ -10,7 +10,7 @@ tags: #good
 
 ```grit
 `new $sym($x)` => `$sym($x)` where {
-  $sym <: `Symbol`
+  $sym <: `Symbol`,
   // make sure it is the pre-defined Symbol, avoid rewriting if `Symbol` is redefined by user
   IsJSGlobalIdentifier($sym)
 }

--- a/.grit/patterns/NoReturnAssign.md
+++ b/.grit/patterns/NoReturnAssign.md
@@ -11,7 +11,7 @@ tags: #good, #se
 ```grit
 ReturnStatement(argument = AssignmentExpression(operator = $operator, left = $var, right = $value)) => [
   // We replace the `return` with two statements, the assignment and an updated `return`
-  AssignmentExpression(operator = $operator, left = $var, right = $value)
+  AssignmentExpression(operator = $operator, left = $var, right = $value),
   `return $var`
 ] where {
   // We explicitly limit the pattern to matching instances where the operator is an assignment operator, to avoid capturing eg == and ===.

--- a/.grit/patterns/NoUnsafeNegation.md
+++ b/.grit/patterns/NoUnsafeNegation.md
@@ -16,7 +16,7 @@ tags: #fix
 
 ```grit
 or {
-  `!$key in $collection` => `!($key in $collection)`
+  `!$key in $collection` => `!($key in $collection)`,
   `!$key instanceof $collection` => `!($key instanceof $collection)`
 }
 ```

--- a/.grit/patterns/NoYodaConditions.md
+++ b/.grit/patterns/NoYodaConditions.md
@@ -10,15 +10,15 @@ tags: #good, #syntax
 
 ```grit
 or {
-  `$x == $y` => `$y == $x`
-  `$x === $y` => `$y === $x`
-  `$x > $y` => `$y < $x`
-  `$x < $y` => `$y > $x`
-  `$x >= $y` => `$y <= $x`
+  `$x == $y` => `$y == $x`,
+  `$x === $y` => `$y === $x`,
+  `$x > $y` => `$y < $x`,
+  `$x < $y` => `$y > $x`,
+  `$x >= $y` => `$y <= $x`,
   `$x <= $y` => `$y >= $x`
 } where {
   // In order to capture a yoda condition, the LHS $x must be a LiteralValue and the RHS $y must not be one
-  $x <: LiteralValue($_)
+  $x <: LiteralValue($_),
   ! $y <: LiteralValue($_)
 }
 

--- a/.grit/patterns/PreferIsNaN.md
+++ b/.grit/patterns/PreferIsNaN.md
@@ -15,7 +15,7 @@ tags: #fix
 ```grit
 or {
   // AnyEquals and AnyNotEquals are helper patterns defined in common.unhack
-  AnyEquals(`NaN`, $x) => `isNaN($x)`
+  AnyEquals(`NaN`, $x) => `isNaN($x)`,
   AnyNotEquals(`NaN`, $x) => `!isNaN($x)`
 }
 ```

--- a/.grit/patterns/PreferSelfClosingTagJSX.md
+++ b/.grit/patterns/PreferSelfClosingTagJSX.md
@@ -26,7 +26,7 @@ pattern HTMLTagsWithPair() = or { HTMLHeadings() , HTMLContainers() , HTMLBlockT
   // In order for a snippet of code to be rewritten, it must satisfy both of the where conditions below
   // $body can be either empty – as the lone '.' represents – or match the syntax-tree node JSXText with the denoted value
   // The r prefix causes the attached string to be interpreted as a regular expression, in this case matching any amount of whitespace
-  $body <: or { . , JSXText(value = r"\\s*") }
+  $body <: or { . , JSXText(value = r"\\s*") },
   // $name must NOT match the syntax-tree node JSXIdentifier with a name attribute equivalent to one of the HTMLTagsWithPair defined at the top of the file
   $name <: ! JSXIdentifier(name = HTMLTagsWithPair())
 }

--- a/.grit/patterns/ReactToHooks.md
+++ b/.grit/patterns/ReactToHooks.md
@@ -10,9 +10,9 @@ tags: #react, #migration, #complex
 // To improve readability, we make extensive use of named patterns defined at the top of the file whose results are ultimately consumed by the final MainReactClassToHooks pattern.
 pattern HandleOneSetState($stateUpdaters) = some {
   let $key, $val, $setter, $capitalized in ObjectProperty`$key: $val` where {
-    $key <: Identifier()
-    $capitalized = capitalize($key)
-    $setter = Identifier(name = s"set${capitalized}")
+    $key <: Identifier(),
+    $capitalized = capitalize($key),
+    $setter = Identifier(name = s"set${capitalized}"),
     $stateUpdaters = [...$stateUpdaters, `$setter($val)`]
   }
 }
@@ -20,44 +20,44 @@ pattern HandleOneSetState($stateUpdaters) = some {
 pattern ChangeThis() = maybe contains or {
   let $props in `const {$props} = this.props` => . where {
       $hoistedProps = [...$hoistedProps, ...$props]
-  }
+  },
   let $states in `const {$states} = this.state` => . where {
       $hoistedStates = [...$hoistedStates, ...$states]
-  }
+  },
   let $states in `this.state = { $states }` => . where {
       $hoistedStates = [...$hoistedStates, ... $states]
-  }
+  },
   bubble or {
     //   TODO: handle prevProps
-    `this.setState($setStateBody, $secondArg)` where $stateUpdaters = [...$stateUpdaters]
+    `this.setState($setStateBody, $secondArg)` where $stateUpdaters = [...$stateUpdaters],
     `this.setState($setStateBody)`
     } => $stateUpdaters where $setStateBody <: or {
-    `{ $stateUpdate }` where $stateUpdate <: HandleOneSetState($stateUpdaters)
+    `{ $stateUpdate }` where $stateUpdate <: HandleOneSetState($stateUpdaters),
     `() => { $bodyLike }` where
      $bodyLike <: HandleOneSetState($stateUpdaters)
-  }
+  },
 
   let $name, $setter, $value, $capitalized in `this.$name = $value` => `$setter($value)` where {
-    $mobxStates <: contains $name
-    $capitalized = capitalize($name)
+    $mobxStates <: contains $name,
+    $capitalized = capitalize($name),
     $setter = Identifier(name = s"set${capitalized}")
-  }
+  },
 
   let $name in `this.$name` => $name where or {
-    $mobxStates <: contains $name
+    $mobxStates <: contains $name,
     $mobxComputedFields <: contains $name
-  }
+  },
 
   bubble or {
     // don't append handler on viewState references
     `this.$vs` => `$vs` where {
       $vs <: or { `viewState`, `viewstate` }
-    }
-    `this.state.$name` => $name
-    `this.props` => `props`
-    `this.state.$foo` => `$foo`
+    },
+    `this.state.$name` => $name,
+    `this.props` => `props`,
+    `this.state.$foo` => `$foo`,
     `this.$name` => `$newName` where $newName = Identifier(name = s"${name}Handler")
-  }
+  },
 
   `ViewState` where {
     $foundViewState = true
@@ -65,215 +65,215 @@ pattern ChangeThis() = maybe contains or {
 }
 
 pattern HandleOneBodyStatement() = or {
-  bubble `constructor($_) { $constructorBody }` where $constructorBody <: ChangeThis()
+  bubble `constructor($_) { $constructorBody }` where $constructorBody <: ChangeThis(),
 
   let $state in ClassProperty(key = `state`, value = ObjectExpression(properties = $state)) where {
     $state <: some let $key, $val, $setter, $capitalized in `$key: $val` where {
-      $key <: Identifier()
-      $capitalized = capitalize($key)
-      $setter = Identifier(name = s"set${capitalized}")
-      $stateStatements = [...$stateStatements, `const [$key, $setter] = useState($val)`]
+      $key <: Identifier(),
+      $capitalized = capitalize($key),
+      $setter = Identifier(name = s"set${capitalized}"),
+      $stateStatements = [...$stateStatements, `const [$key, $setter] = useState($val)`],
       ensureImportFrom(`useState`, `"react"`)
     }
-  }
+  },
 
   let $updateEffectBody in ClassMethod(key = `componentDidUpdate`, body = $updateEffectBody) where {
-    ensureImportFrom(`useEffect`, `"react"`)
-    $updateEffectBody <: ChangeThis()
+    ensureImportFrom(`useEffect`, `"react"`),
+    $updateEffectBody <: ChangeThis(),
     $updateEffect = [ `useEffect(() => $updateEffectBody, [])` ]
 
     // if ($updateEffectBody <: contains {`prevProps`}) then {
     //   $updateEffect = [...$updateEffect, `TODO("the above effect references previous props")`]
     // } else {}
-  }
+  },
 
   let $mountEffectBody in ClassMethod(key = `componentDidMount`, body = $mountEffectBody) where {
     if $oldBody <: contains `componentDidUpdate() { $mountEffectBody }` then {
       $mountEffect = []
     } else {
-      $mountEffect = `useEffect(() => $mountEffectBody, [])`
-      ensureImportFrom(`useEffect`, `"react"`)
+      $mountEffect = `useEffect(() => $mountEffectBody, [])`,
+      ensureImportFrom(`useEffect`, `"react"`),
       $mountEffectBody <: ChangeThis()
     }
-  }
+  },
 
   let $unmountBody in ClassMethod(key = `componentWillUnmount`, body = $unmountBody) where {
-    $unmountEffect = `useEffect(() => { return () => $unmountBody })`
-    ensureImportFrom(`useEffect`, `"react"`)
+    $unmountEffect = `useEffect(() => { return () => $unmountBody })`,
+    ensureImportFrom(`useEffect`, `"react"`),
     $unmountBody <: ChangeThis()
-  }
+  },
 
   `render() { $renderBody }` where {
-    $renderBody <: ChangeThis()
+    $renderBody <: ChangeThis(),
     $renderBody <: some or {
-      `const {$_} = this.props`
-      `const {$_} = this.state`
-      `const {$_} = this`
+      `const {$_} = this.props`,
+      `const {$_} = this.state`,
+      `const {$_} = this`,
       let $keep in $keep where $savedRenderBody = [ ... $savedRenderBody, $keep ]
-    }
+    },
     $newRenderBody = $savedRenderBody
-  }
+  },
   // statics
   let $staticFuncName, $staticFuncBody, $args in or {
-    `static $staticFuncName = ($args) => { $staticFuncBody }`
+    `static $staticFuncName = ($args) => { $staticFuncBody }`,
     `static $staticFuncName($args) { $staticFuncBody }`
   } where {
     $staticMethods = [ ... $staticMethods, `$name.$staticFuncName = ($args) => { $staticFuncBody }`]
-  }
+  },
   let $defaultProps in `static defaultProps = { $defaultProps }` where {
-    $finalDefaultProps = [`const props = { $defaultProps, ...inputProps }`]
+    $finalDefaultProps = [`const props = { $defaultProps, ...inputProps }`],
     $movedDefaultProps = true
-  }
+  },
   let $staticProp, $staticValue in `static $staticProp = $staticValue` where {
     $staticProps = [ ... $staticProps, `$name.$staticProp = $staticValue` ]
-  }
+  },
   let $funcName, $funcBody in ClassMethod(key = $funcName, body = $funcBody, kind = "get", params = [], static = false, decorators = [`@computed`]) where {
-    $mobxComputed = [ ... $mobxComputed, `const $funcName = useMemo(() => $funcBody, [ $mobxStates ])` ]
+    $mobxComputed = [ ... $mobxComputed, `const $funcName = useMemo(() => $funcBody, [ $mobxStates ])` ],
     $funcBody <: ChangeThis()
-  }
+  },
 
   let $funcName, $funcBody, $args in ClassMethod(key = $funcName, body = $funcBody, params = $args, static = false) where {
-    $newName = s"${funcName}Handler"
+    $newName = s"${funcName}Handler",
     if ($funcBody <: contains `await $_` ) then {
       $callbacks = [...$callbacks, `const $newName = useCallback(async ($args) => $funcBody, [])`]
     } else {
       $callbacks = [...$callbacks, `const $newName = useCallback(($args) => $funcBody, [])`]
-    }
-    ensureImportFrom(`useCallback`, `"react"`)
+    },
+    ensureImportFrom(`useCallback`, `"react"`),
     $funcBody <: ChangeThis()
-  }
+  },
 
   let $funcName, $entireFunc, $vars in ClassProperty(key = $funcName, value = `($_) => { $_ }` as $entireFunc) where {
-    $newName = s"${funcName}Handler"
-    $callbacks = [...$callbacks, `const $newName = useCallback($entireFunc, [])`]
-    ensureImportFrom(`useCallback`, `"react"`)
+    $newName = s"${funcName}Handler",
+    $callbacks = [...$callbacks, `const $newName = useCallback($entireFunc, [])`],
+    ensureImportFrom(`useCallback`, `"react"`),
     $entireFunc <: ChangeThis()
-  }
+  },
 
   let $stateVar, $initValue, $typeArgs in ClassProperty(key = $stateVar, value = $initValue, typeAnnotation = $typeArgs, decorators = contains `@observable`) where {
     $hoistedStates = [ ...$hoistedStates, ClassProperty(key = $stateVar, value = $initValue, typeAnnotation = $typeArgs) ]
-  }
+  },
 
   bubble($mobxEffects) { `$_ = reaction(() => $depends, ($_) => $effect)` where {
-    $newDepends = []
+    $newDepends = [],
     // TODO: this is a bit of a hack to remove the `this` from dependencies by rebuilding newDepends
-    $depends <: maybe { contains bubble($newDepends) `this.$z` where $newDepends = [$newDepends, $z] }
-    $mobxEffects = [ ... $mobxEffects, `useEffect(() => $effect, [$newDepends])`]
+    $depends <: maybe { contains bubble($newDepends) `this.$z` where $newDepends = [$newDepends, $z] },
+    $mobxEffects = [ ... $mobxEffects, `useEffect(() => $effect, [$newDepends])`],
     $effect <: ChangeThis()
-  } }
+  } },
 
   // handling remaining class properties
   let $name, $value in ClassProperty(key = $name, value = $value, decorators = not contains `@observable`) where {
-    $otherProperties = [ ...$otherProperties, `const $name = useRef($value)` ]
-    ensureImportFrom(`useRef`, `"react"`)
+    $otherProperties = [ ...$otherProperties, `const $name = useRef($value)` ],
+    ensureImportFrom(`useRef`, `"react"`),
     $value <: ChangeThis()
   }
 }
 
 pattern CollectMobxFields() = let $stateVar, $funcName in or {
-  ClassProperty(key = $stateVar, decorators = [`@observable`], static = false) where $mobxStates = [ ... $mobxStates, $stateVar ]
+  ClassProperty(key = $stateVar, decorators = [`@observable`], static = false) where $mobxStates = [ ... $mobxStates, $stateVar ],
   ClassMethod(key = $funcName, kind = "get", params = [], static = false, decorators = [`@computed`]) where $mobxComputedFields = [ ... $mobxComputedFields, $funcName ]
 }
 
 predicate HandleHoistedStates() = {
   $hoistedStates <: maybe contains let $name, $theValue, $current, $initValue, $setter, $capitalized, $theType, $theUpdate in
     or {
-      ObjectProperty(key = $current, value = $theValue) where $theType = null
+      ObjectProperty(key = $current, value = $theValue) where $theType = null,
       ClassProperty(key = $current, value = $theValue, typeAnnotation = $theType)
     } where {
-      $capitalized = capitalize($current)
-      $setter = Identifier(name = s"set${capitalized}")
+      $capitalized = capitalize($current),
+      $setter = Identifier(name = s"set${capitalized}"),
 
-      if($theValue <: $current) $initValue = [] else $initValue = $theValue
-      if($initValue <: null) $initValue = `undefined`
+      if($theValue <: $current) $initValue = [] else $initValue = $theValue,
+      if($initValue <: null) $initValue = `undefined`,
 
-      $theValue <: ChangeThis()
-      $current <: not `defaultProps`
+      $theValue <: ChangeThis(),
+      $current <: not `defaultProps`,
 
       if($theType <: null) {
         $theUpdate = `const [$current, $setter] = useState($initValue)`
       } else {
         $theUpdate = `const [$current, $setter] = useState<$theType>($initValue)`
-      }
-      $newState = [...$newState, $theUpdate]
+      },
+      $newState = [...$newState, $theUpdate],
       ensureImportFrom(`useState`, `"react"`)
   } until [$_] // remove until after generalizing `...` to match assoc on assigned metavars
 }
 
 pattern MainReactClassToHooks($moveDefaultProps) = or {
-  `class $name extends $component<$propType> {$oldBody }`
+  `class $name extends $component<$propType> {$oldBody }`,
   // Check for a class component with no base, so that we match both class components with and without explicit typing.
   `class $name extends $component {$oldBody }` where { $propType = `any` }
   // The overall class $name extends React.Component pattern is aliased as $match to improve readability.
 } as $match => $newStatements where {
-  $component <: or { `Component`, `React.Component` }
+  $component <: or { `Component`, `React.Component` },
   // TODO: figure out how error boundaries should be converted
-  $oldBody <: not contains { `componentDidCatch` }
+  $oldBody <: not contains { `componentDidCatch` },
 
-  $hoistedProps = []
-  $hoistedStates = []
-  $mobxStates = []
-  $mobxComputedFields = []
-  $foundViewState = false
-  $movedDefaultProps = false
+  $hoistedProps = [],
+  $hoistedStates = [],
+  $mobxStates = [],
+  $mobxComputedFields = [],
+  $foundViewState = false,
+  $movedDefaultProps = false,
 
   // nested components are not currently supported
-  !$match <: within { ClassDeclaration(id = !$name) }
+  !$match <: within { ClassDeclaration(id = !$name) },
 
   // The ReactToHooks migration supports migrating React Mobx components, but "maybe" ensures that Mobx is optional.
-  $oldBody <: maybe some CollectMobxFields()
+  $oldBody <: maybe some CollectMobxFields(),
 
   // The body of a React class component will have at least one body statement since the render() method is required, so "maybe" is not necessary here.
-  $oldBody <: some HandleOneBodyStatement()
+  $oldBody <: some HandleOneBodyStatement(),
 
   // React class components can have default props as the static property defaultProps.
   // We remove this code entirely (the " => . " transformation) and assign the conjunction of the default props and input props to the metavariable $finalDefaultProps for later use.
   if ($moveDefaultProps <: true) then {
     $oldBody <: maybe let($defaultProps) {
         contains `$name.defaultProps = { $defaultProps }` => . where {
-        $finalDefaultProps = [`const props = { $defaultProps, ...inputProps }`]
+        $finalDefaultProps = [`const props = { $defaultProps, ...inputProps }`],
         $movedDefaultProps = true
       }
     }
-  }
+  },
 
-  HandleHoistedStates()
+  HandleHoistedStates(),
 
   // $hoistedProps began as an empty list at the beginning of this pattern, but may have been mutated by ChangeThis() called within HandleOneBodyStatement().
   // distinct() is one of several utility functions built into the engine.
-  $finalProps = distinct($hoistedProps)
+  $finalProps = distinct($hoistedProps),
 
   // The output of the ReactToHooks migration destructures the props object if the input contained any props.
-  if (! $finalProps <: [] ) $propsInit = `const { $finalProps } = props` else $propsInit = .
+  if (! $finalProps <: [] ) $propsInit = `const { $finalProps } = props` else $propsInit = .,
 
   // When we use the ... operator to assemble $newBody, Grit's syntax-aware code generation process produces the output code in a reasonable format.
-  $newBody = [ ... $finalDefaultProps, ... $newState, ... $propsInit, ... $stateStatements, ... $constructorBody, ...$mountEffect, ...$unmountEffect, ...$updateEffect, ... $callbacks, ... $mobxComputed, ... $mobxEffects, ... $otherProperties, ... $newRenderBody ]
+  $newBody = [ ... $finalDefaultProps, ... $newState, ... $propsInit, ... $stateStatements, ... $constructorBody, ...$mountEffect, ...$unmountEffect, ...$updateEffect, ... $callbacks, ... $mobxComputed, ... $mobxEffects, ... $otherProperties, ... $newRenderBody ],
 
   // If we moved default props defined as static class variables earlier in the pattern, we now set $propsArgName to be "inputProps" instead of "props" so that our rewritten `const props = { $defaultProps, ...inputProps }` snippet syntactically coheres.
   if ($moveDefaultProps <: true && $movedDefaultProps <: true) then {
     $propsArgName = `inputProps`
   } else {
     $propsArgName = `props`
-  }
+  },
 
   if (or { $oldBody <: contains or {`this.props`, `static defaultProps`} , $movedDefaultProps <: true }) then {
     $propsArg = $propsArgName
   } else {
     $propsArg = []
-  }
+  },
 
   if (IsTypeScript()) {
     $funcDef = `($propsArg: $propType) => { $newBody }`
   } else {
     $funcDef = `($propsArg) => { $newBody }`
-  }
+  },
 
   if($foundViewState <: true) {
-    $funcDef = `observer(($propsArg) => { $newBody })`
+    $funcDef = `observer(($propsArg) => { $newBody })`,
     // ensureImportFrom is a utility predicate defined in common.unhack
     ensureImportFrom(`observer`, `"mobx-react"`)
-  }
-  $theFunction = `const $name = $funcDef`
+  },
+  $theFunction = `const $name = $funcDef`,
 
   // Finally, we assemble the $newStatement metavariable declared all the way at the top of the MainReactClassToHooks pattern.
   // $theFunction comprises the const () => {} format of React function components, while static props and static methods are declared outside the body of the function as properties of the function itself.

--- a/.grit/patterns/RemoveNodeBufferOffsetCheckFlag.md
+++ b/.grit/patterns/RemoveNodeBufferOffsetCheckFlag.md
@@ -13,16 +13,16 @@ tags: #security, #fix, #node
 pattern Falsy() = or { `0`, `""`, `''`, TemplateLiteral(quasis = "``"), `null`, `undefined`, `NaN` }
 
 pattern OneArg() = or {
-  `readUInt16LE` , `readUInt16BE` , `readInt8`
-  `readInt16LE` , `readInt16BE` , `readInt32LE` , `readInt32BE`
+  `readUInt16LE` , `readUInt16BE` , `readInt8`,
+  `readInt16LE` , `readInt16BE` , `readInt32LE` , `readInt32BE`,
   `readFloatLE` , `readFloatBE` , `readDoubleLE` , `readDoubleBE`
 }
 
 pattern TwoArgs() = or {
-  `readUIntLE` , `readUIntBE` , `readIntLE` , `readIntBE` , `writeUInt8` , `readUInt8`
-  `writeUInt32LE` , `writeUInt32BE` , `writeUInt16LE` , `writeUInt16BE`
-  `writeInt32LE` , `writeInt32BE` , `writeInt16LE` , `writeInt16BE`
-  `writeFloatLE` , `writeFloatBE` , `writeFloatLE` , `writeFloatBE`
+  `readUIntLE` , `readUIntBE` , `readIntLE` , `readIntBE` , `writeUInt8` , `readUInt8`,
+  `writeUInt32LE` , `writeUInt32BE` , `writeUInt16LE` , `writeUInt16BE`,
+  `writeInt32LE` , `writeInt32BE` , `writeInt16LE` , `writeInt16BE`,
+  `writeFloatLE` , `writeFloatBE` , `writeFloatLE` , `writeFloatBE`,
   `writeDoubleLE` , `writeDoubleBE` , `writeDoubleLE` , `writeDoubleBE`
 }
 
@@ -31,13 +31,13 @@ pattern ThreeArgs() = or { `writeUIntLE` , `writeUIntBE` , `writeIntLE` , `write
 // Buffer has methods with one, two or three arguments before a final argument to set the noAssert flag.
 // The or conditions match each of these scenarios respectively, while binding the final argument to the $theFlag metavariable.
 or {
-  `$_.$name($_, $theFlag)` where $name <: OneArg()
-  `$_.$name($_, $_, $theFlag)` where $name <: TwoArgs()
+  `$_.$name($_, $theFlag)` where $name <: OneArg(),
+  `$_.$name($_, $_, $theFlag)` where $name <: TwoArgs(),
   `$_.$name($_, $_, $_, $theFlag)` where $name <: ThreeArgs()
 } where {
   // If $theFlag does not match one of the Falsy() values, then the noAssert flag is set to true in the input source code and should be removed.
   // '.' represents the concept of empty, so => . removes $theFlag entirely when $theFlag is not a falsy value.
-  $theFlag <: $x => .
+  $theFlag <: $x => .,
   ! $x <: Falsy()
 }
 ```

--- a/.grit/patterns/RemoveShouldComponentUpdateFromPureComponents.md
+++ b/.grit/patterns/RemoveShouldComponentUpdateFromPureComponents.md
@@ -13,7 +13,7 @@ tags: #fix, #React
 ```grit
 `class $_ extends $extended { $body }` where {
   // The contains clause ensures that the pattern above matches only if the $extended metavariable binds to code containing 'PureComponent'
-  $extended <: contains `PureComponent`
+  $extended <: contains `PureComponent`,
   // The condition below is simultaneously a rewrite, which applies to instances of 'shouldComponentUpdate($_) { $_ }' which are contained in code bound to the metavariable $body.
   // The wildcard metavariable $_ is used because we don't care what the arguments or body of shouldComponentUpdate are; we just want to remove the whole code block.
   $body <: contains `shouldComponentUpdate($_) { $_ }` => .

--- a/.grit/patterns/common.grit
+++ b/.grit/patterns/common.grit
@@ -66,6 +66,23 @@ predicate AddImport($m, $fromArg) =
     or { and { ! $from <: $froms, $froms = or { $froms, $from } }, true }
   }
 
+predicate AddNamespaceImport($m, $fromArg) =
+   $fromArg <: let($alias, $from) and {
+    or {
+      Identifier() as $alias,
+      $_ where $alias = Identifier(name = $m)
+    },
+    or {
+      StringLiteral() as $from,
+      $_ where $from = StringLiteral(value = $fromArg)
+    }
+  } where {
+    $importDeclaration = ImportNamespaceSpecifier(local = $alias, id = null, name = null),
+    $alreadySolved = or { $alreadySolved, $importDeclaration },
+    $solvedPairs = or { $solvedPairs, `$importDeclaration, $from` },
+    or { and { ! $from <: $froms, $froms = or { $froms, $from } }, true }
+  }
+
 predicate ReplaceImport($m, $from) = {
   RemoveImport($m),
   AddImport($m, $from)
@@ -124,7 +141,11 @@ predicate IsGlobalVariable($id) = {
 predicate InsertImports() = or {
   and {
     $froms <: let $from, $allFrom, $fromName in $from where {
-      $solvedPairs <: maybe { let $x in `$x, $from` where { $allFrom = [... $allFrom, $x] } },
+      $solvedPairs <: maybe { 
+        let $x in `$x, $from` where { 
+          $allFrom = [... $allFrom, $x]
+        }
+      },
       $from <: StringLiteral(value = $fromName),
       or {
         $program <: let $existing, $fromHere in {
@@ -142,7 +163,7 @@ predicate InsertImports() = or {
       }
     },
     or {
-      $allNewImports <: []
+      $allNewImports <: [],
       InsertAfterImports($allNewImports)
     }
   },

--- a/.grit/patterns/common.grit
+++ b/.grit/patterns/common.grit
@@ -3,7 +3,7 @@ pattern AnyEquals($a, $b) = or { `$a == $b` , `$a === $b` , `$b == $a` , `$b ===
 pattern AnyAnd($a, $b) = or { `$a && $b` , `$b && $a` }
 
 pattern AnyNotEquals($a, $b) = or {
-  BinaryExpression(operator = or { "!==" , "!=" }, left = $a, right = $b)
+  BinaryExpression(operator = or { "!==" , "!=" }, left = $a, right = $b),
   BinaryExpression(operator = or { "!==" , "!=" }, left = $b, right = $a)
 }
 
@@ -12,17 +12,17 @@ pattern BuiltInObjects() = or { `Object`, `Math`, `Array`, `Number`, `Date`, `Re
 pattern AnyEqualsUndefined($aVar) = AnyEquals($aVar,`undefined`)
 
 pattern LiteralValue($v) = or {
-  JSXText(value = $v)
-  StringLiteral(value = $v)
-  NumericLiteral(value = $v)
-  BigIntLiteral(value = $v)
-  NullLiteral(value = $v)
-  BooleanLiteral(value = $v)
+  JSXText(value = $v),
+  StringLiteral(value = $v),
+  NumericLiteral(value = $v),
+  BigIntLiteral(value = $v),
+  NullLiteral(value = $v),
+  BooleanLiteral(value = $v),
   RegExpLiteral(value = $v)
 }
 
 pattern ImportNameFrom($name, $from) = or {
-  `import { $..., $name, $... } from '$from'`
+  `import { $..., $name, $... } from '$from'`,
   let $somethingelse in `import { $..., $somethingelse as $name, $... } from '$from'` where warning s"$name imported but as an alias of $somethingelse" on $name
 }
 
@@ -45,55 +45,38 @@ predicate IsUsed($name) = {
 predicate RemoveImportIfUnused($name) = (! IsUsed($name)) && RemoveImport($name)
 
 predicate IsTypeScript() = $program <: or {
-    File(name = or { r".*tsx?", r".*ts?" })
+    File(name = or { r".*tsx?", r".*ts?" }),
     File(program = contains { TSTypeAnnotation() })
 }
 
 pattern ImportedFrom($from) = $name where or {
-    $name <: semantic within ImportNameFrom($name, $from)
-    $name <: semantic `require($from)`
+    $name <: semantic within ImportNameFrom($name, $from),
+    $name <: semantic `require($from)`,
     IsImported($name, $from)
   }
 
 predicate AddImport($m, $fromArg) =
   $fromArg <: let $from in or {
-    StringLiteral() as $from
+    StringLiteral() as $from,
     $_ where $from = StringLiteral(value = $fromArg)
   } where {
-    ! $m <: $alreadySolved
-    $alreadySolved = or { $alreadySolved, $m }
-    $solvedPairs = or { $solvedPairs, `$m, $from` }
-    or { and { ! $from <: $froms, $froms = or { $froms, $from } }, true }
-  }
-
-predicate AddNamespaceImport($m, $fromArg) =
-   $fromArg <: let($alias, $from) and {
-    or {
-      Identifier() as $alias
-      $_ where $alias = Identifier(name = $m)
-    }
-    or {
-      StringLiteral() as $from
-      $_ where $from = StringLiteral(value = $fromArg)
-    }
-  } where {
-    $importDeclaration = ImportNamespaceSpecifier(local = $alias, id = null, name = null)
-    $alreadySolved = or { $alreadySolved, $importDeclaration }
-    $solvedPairs = or { $solvedPairs, `$importDeclaration, $from` }
+    ! $m <: $alreadySolved,
+    $alreadySolved = or { $alreadySolved, $m },
+    $solvedPairs = or { $solvedPairs, `$m, $from` },
     or { and { ! $from <: $froms, $froms = or { $froms, $from } }, true }
   }
 
 predicate ReplaceImport($m, $from) = {
-  RemoveImport($m)
+  RemoveImport($m),
   AddImport($m, $from)
 }
 
 pattern EnsureImportFrom($from) = and {
-  Identifier()
+  Identifier(),
   or {
-    let $alreadyImported in $alreadyImported where { IsImported($alreadyImported, $_), warning "Already imported" on $alreadyImported }
-    ImportedFrom($from)
-    let $m in $m where AddImport($m, $from)
+    let $alreadyImported in $alreadyImported where { IsImported($alreadyImported, $_), warning "Already imported" on $alreadyImported },
+    ImportedFrom($from),
+    let $m in $m where AddImport($m, $from),
     $_
   }
 }
@@ -103,15 +86,15 @@ predicate IsUsed($name) = $program <: contains $name until or { `$name = $_`, Va
 predicate IsJSGlobalIdentifier($var) = $var <: Identifier(binding = not ["root", ...])
 
 pattern EnsureRelativeImportFrom($current, $imported) = let $directory, $importedPath, $name in $name where {
-  $current <: r"(.*)/.*"($directory)
-  $importedPath = relative($directory, $imported)
+  $current <: r"(.*)/.*"($directory),
+  $importedPath = relative($directory, $imported),
   $name <: EnsureImportFrom(StringLiteral(value = $importedPath))
 }
 
 pattern EnsureImportedFrom($imported) = let $directory, $importedPath, $name, $current in $name where {
-  $program <: File($_, $current)
-  $current <: r"(.*)/.*"($directory)
-  $importedPath = relative($directory, $imported)
+  $program <: File($_, $current),
+  $current <: r"(.*)/.*"($directory),
+  $importedPath = relative($directory, $imported),
   $name <: EnsureImportFrom(StringLiteral(value = $importedPath))
 }
 
@@ -141,46 +124,42 @@ predicate IsGlobalVariable($id) = {
 predicate InsertImports() = or {
   and {
     $froms <: let $from, $allFrom, $fromName in $from where {
-      $solvedPairs <: maybe { 
-        let $x in `$x, $from` where { 
-          $allFrom = [... $allFrom, $x]
-        }
-      }
-      $from <: StringLiteral(value = $fromName)
+      $solvedPairs <: maybe { let $x in `$x, $from` where { $allFrom = [... $allFrom, $x] } },
+      $from <: StringLiteral(value = $fromName),
       or {
         $program <: let $existing, $fromHere in {
           File(Program([
             ...
             ImportDeclaration(specifiers = $existing, source = $fromHere, importKind = "value") where {
-              $existing <: not [ImportNamespaceSpecifier()]
-              $fromHere <: StringLiteral(value = $fromName)
+              $existing <: not [ImportNamespaceSpecifier()],
+              $fromHere <: StringLiteral(value = $fromName),
               $existing => [ $existing, $allFrom ]
             }
             ...
           ]), $_)
-        }
+        },
         $allNewImports = [$allNewImports, `import { $allFrom } from '$from'`]
       }
-    }
+    },
     or {
       $allNewImports <: []
       InsertAfterImports($allNewImports)
     }
-  }
+  },
   true
 }
 
 pattern PreludeRun() = $_ where {
-  $alreadySolved = or { }
-  $solvedPairs = or { }
-  $froms = or { }
+  $alreadySolved = or { },
+  $solvedPairs = or { },
+  $froms = or { },
   $allNewImports = []
 }
 
 pattern ConclusionRun() = InsertImports()
 
 pattern FunctionLike($name, $args, $statements) = or {
-  `function $name($args) { $statements }`
-  `($args) => { $statements }`
+  `function $name($args) { $statements }`,
+  `($args) => { $statements }`,
   `($args) => $statements`
 }

--- a/.grit/patterns/react.grit
+++ b/.grit/patterns/react.grit
@@ -1,6 +1,6 @@
 predicate AddToStateDefs($stateDefs, $key, $initialVal) = $key <: let $capitalized, $setter in $_ where {
-  $capitalized = capitalize($key)
-  $setter = Identifier(name = s"set${capitalized}")
+  $capitalized = capitalize($key),
+  $setter = Identifier(name = s"set${capitalized}"),
   $stateDefs = [...$stateDefs, `const [$key, $setter] = useState($initialVal)`]
 }
 
@@ -9,6 +9,6 @@ predicate DoubleBraceToSingle($inval, $outval) = {
 }
 
 pattern ReactNode($name, $props, $children) = or {
-    `<$name $props>$children</$name>`
+    `<$name $props>$children</$name>`,
     `<$name $props />`
 }


### PR DESCRIPTION
Add comma to pattern lists so tree-sitter grammar will be able to parse after update.

Tested against engine to ensure engine can still process, and tree-sitter grammar can still parse.