### PR TITLE
fix: handle dotenv in ES6Imports

### DIFF
--- a/.grit/patterns/ES6Imports.md
+++ b/.grit/patterns/ES6Imports.md
@@ -18,6 +18,8 @@ or {
     `const $import = require($source).default` => `import $import from "$source"`
     `const $import = require($source).$foo` => `import { $foo as $import } from "$source"`
     `const $import = require($source)` => `import $import from "$source"` // this relies on healing for correctness
+    // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
+    `require("dotenv").config($config)` => [`import * as dotenv from 'dotenv'`, `dotenv.config($config)`]
 }
 ```
 
@@ -26,15 +28,39 @@ or {
 ```js
 const defaultImport = require("../../shared/default").default;
 const { something, another } = require("./lib");
-const assert = require('chai').assert 
-const conf = require('chai').config;
+const assert = require("chai").assert;
+const conf = require("chai").config;
 const starImport = require("star");
 ```
 
 ```ts
 import defaultImport from "../../shared/default";
 import { something, another } from "./lib";
-import { assert } from 'chai';
-import { config as conf } from 'chai';
+import { assert } from "chai";
+import { config as conf } from "chai";
 import starImport from "star";
+```
+
+### Handle dotenv
+
+```
+require("dotenv").config({ path: "../.env" });
+
+// Another example
+require("dotenv").config();
+
+function doStuff() {
+    // hello world
+}
+```
+
+```
+import * as dotenv from 'dotenv';
+dotenv.config({ path: "../.env" });
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+function doStuff() {
+    // hello world
+}
 ```


### PR DESCRIPTION
This seems pretty straightforward and common enough that it's worth catching.