### PR TITLE
add ES6ImportsToRequire

### DIFF
--- a/.grit/patterns/ES6Imports.md
+++ b/.grit/patterns/ES6Imports.md
@@ -4,7 +4,7 @@ title: Prefer imports over require
 
 # ES6 imports
 
-Converts `require` statements to ES6-style exports.
+Converts `require` statements to ES6-style `import`.
 
 tags: #js, #es6, #migration, #cjs, #commonjs
 

--- a/.grit/patterns/ES6ImportsToRequire.md
+++ b/.grit/patterns/ES6ImportsToRequire.md
@@ -1,0 +1,56 @@
+---
+title: Prefer require over imports
+---
+
+# ES6 imports to require
+
+Converts ES6-style `import` to `require` statements.
+
+tags: #js, #es6, #migration, #cjs, #commonjs
+
+```grit
+or {
+    `import $import from "$source"` => `const $import = require("$source")`
+    `import { $import } from "$source"` => `const { $newports } = require("$source")` where {
+        $newports = []
+        $import <: some bubble($newports) `$key as $val` where { 
+            $obj = ObjectProperty(key=$key, value=$val)
+            // no need to do {foo: foo}, just say {foo}
+            if ($key <: $val) {
+                $obj = $key
+            }
+            $newports = [...$newports, $obj]
+        }
+    }
+}
+```
+
+## Transform standard require statements
+
+```ts
+import { something, another } from "./lib";
+import { assert } from 'chai';
+import { config as conf } from 'chai';
+import starImport from "star";
+
+ // no special handling for default. Also, comments get removed.
+import defaultImport from "../../shared/default";
+```
+
+```ts
+const {
+  something,
+  another
+} = require("./lib");
+
+const {
+  assert
+} = require('chai');
+
+const {
+  config: conf
+} = require('chai');
+
+const starImport = require("star");
+const defaultImport = require("../../shared/default");
+```


### PR DESCRIPTION
Reference because needed for JS2TS hack (though won't literally use this pattern)

I suppose we could parameterize it if we wanted to?