### PR TITLE
feat: ES6Exports handles export of a require

### DIFF
--- a/.grit/patterns/ES6Exports.md
+++ b/.grit/patterns/ES6Exports.md
@@ -16,13 +16,29 @@ or {
             $vals <: some let($key, $name, $val, $match, $prop) ObjectProperty(key=$key, value=$name) as $prop => . where {
                 $name <: Identifier()
                 $exportedVals = [... $exportedVals, $prop]
-                $program <: contains or {
-                    `const $name = $val`
-                    `let $name = $val`
-                    `var $name = $val`
-                    `const $name = $val`
-                    FunctionDeclaration(id=$name)
-                } as $match => ExportNamedDeclaration(declaration=$match)
+                or {
+                    // special case of exporting a require() - see ES6Import pattern
+                    $program <: contains or {
+                        // TODO difficult to handle matching a sublist of the module.exports
+                        // `const { $imports } = require($val)` => `export { $transformed } from "$val"` where {
+                        //     $imports <: some bubble($transformed, $name) {ObjectProperty(key=$subkey, value=$subval) where {
+                        //         $subval <: $name
+                        //         $transformed = [...$transformed, `$subkey as $subval`]
+                        //     } }
+                        // }
+                        `const $name = require($val).default` => `export { default as $name } from "$val"`
+                        `const $name = require($val).$foo` => `export { $foo as $name } from "$val"`
+                        `const $name = require($val)` => `export { default as $name } from "$val"`
+                    }
+                    // normal case
+                    $program <: contains or {
+                        `const $name = $val`
+                        `let $name = $val`
+                        `var $name = $val`
+                        `const $name = $val`
+                        FunctionDeclaration(id=$name)
+                    } as $match => ExportNamedDeclaration(declaration=$match)
+                }
             }
         }
         maybe `module.exports = { $vals }` => . where $vals <: $exportedVals
@@ -81,4 +97,32 @@ export const king = "9";
 module.exports = {
   queen: "8"
 };
+```
+
+### Work on 
+
+```js
+const c1 = require("./mod1");
+const c2 = require("./mod2");
+const c3 = require("./mod3");
+const myDefaultConst = require("./mod4").default;
+const myRenamed = require("mod5").originalName;
+const { sub1, sub2 } = require("mod5"); // not handled
+
+module.exports = { c1, c2, c3, myDefaultConst, myRenamed, sub1, sub2 };
+```
+
+```js
+export { default as c1 } from "./mod1";
+export { default as c2 } from "./mod2";
+export { default as c3 } from "./mod3";
+export { default as myDefaultConst } from "./mod4";
+export { originalName as myRenamed } from "mod5";
+const { sub1, sub2 } = require("mod5"); // not handled
+
+module.exports = {
+  sub1,
+  sub2
+};
+
 ```

--- a/.grit/patterns/ES6Exports.md
+++ b/.grit/patterns/ES6Exports.md
@@ -16,16 +16,16 @@ or {
             $vals <: some let($key, $name, $val, $match, $prop) ObjectProperty(key=$key, value=$name) as $prop => . where {
                 $name <: Identifier()
                 $exportedVals = [... $exportedVals, $prop]
-                or {
+                $program <: contains or {
                     // special case of exporting a require() - see ES6Import pattern
-                    $program <: contains or {
+                    or {
                         // does not handle difficult trying to match a sublist of the module.exports
                         `const $name = require($val).default` => `export { default as $name } from "$val"`
                         `const $name = require($val).$foo` => `export { $foo as $name } from "$val"`
                         `const $name = require($val)` => `export { default as $name } from "$val"`
                     }
                     // normal case
-                    $program <: contains or {
+                    or {
                         `const $name = $val`
                         `let $name = $val`
                         `var $name = $val`

--- a/.grit/patterns/ES6Exports.md
+++ b/.grit/patterns/ES6Exports.md
@@ -19,13 +19,7 @@ or {
                 or {
                     // special case of exporting a require() - see ES6Import pattern
                     $program <: contains or {
-                        // TODO difficult to handle matching a sublist of the module.exports
-                        // `const { $imports } = require($val)` => `export { $transformed } from "$val"` where {
-                        //     $imports <: some bubble($transformed, $name) {ObjectProperty(key=$subkey, value=$subval) where {
-                        //         $subval <: $name
-                        //         $transformed = [...$transformed, `$subkey as $subval`]
-                        //     } }
-                        // }
+                        // does not handle difficult trying to match a sublist of the module.exports
                         `const $name = require($val).default` => `export { default as $name } from "$val"`
                         `const $name = require($val).$foo` => `export { $foo as $name } from "$val"`
                         `const $name = require($val)` => `export { default as $name } from "$val"`

--- a/.grit/patterns/ES6Imports.md
+++ b/.grit/patterns/ES6Imports.md
@@ -54,7 +54,7 @@ function doStuff() {
 }
 ```
 
-```js
+```ts
 import * as dotenv from 'dotenv';
 dotenv.config({ path: "../.env" });
 import * as dotenv from 'dotenv';
@@ -63,22 +63,4 @@ dotenv.config();
 function doStuff() {
     // hello world
 }
-```
-
-### Work with exports
-
-```ts
-export subscriptionValidations from "./subscriptionValidations";
-export checkActiveListing from "./checkActiveListing";
-export categoryValidations from "./categoryValidations";
-
-const starImport = require("star");
-```
-
-```ts
-export subscriptionValidations from "./subscriptionValidations";
-export checkActiveListing from "./checkActiveListing";
-export categoryValidations from "./categoryValidations";
-
-import starImport from "star";
 ```

--- a/.grit/patterns/ES6Imports.md
+++ b/.grit/patterns/ES6Imports.md
@@ -43,7 +43,7 @@ import starImport from "star";
 
 ### Handle dotenv
 
-```
+```js
 require("dotenv").config({ path: "../.env" });
 
 // Another example
@@ -54,7 +54,7 @@ function doStuff() {
 }
 ```
 
-```
+```js
 import * as dotenv from 'dotenv';
 dotenv.config({ path: "../.env" });
 import * as dotenv from 'dotenv';
@@ -63,4 +63,22 @@ dotenv.config();
 function doStuff() {
     // hello world
 }
+```
+
+### Work with exports
+
+```ts
+export subscriptionValidations from "./subscriptionValidations";
+export checkActiveListing from "./checkActiveListing";
+export categoryValidations from "./categoryValidations";
+
+const starImport = require("star");
+```
+
+```ts
+export subscriptionValidations from "./subscriptionValidations";
+export checkActiveListing from "./checkActiveListing";
+export categoryValidations from "./categoryValidations";
+
+import starImport from "star";
 ```


### PR DESCRIPTION
Resolves https://github.com/getgrit/rewriter/issues/3903

Studio: https://app.grit.io/studio?key=Jj-uMNIKi-lQBbmn5I6bH

This can handle the basic case, but cannot handle this:

```
const { sub1, sub2 } = require("mod5"); // not handled
module.exports = {
  sub1,
  sub2
};
```

It's just difficult to handle matching a sublist of the module.exports
```
                        // TODO difficult to handle matching a sublist of the module.exports
                        // `const { $imports } = require($val)` => `export { $transformed } from "$val"` where {
                        //     $imports <: some bubble($transformed, $name) {ObjectProperty(key=$subkey, value=$subval) where {
                        //         $subval <: $name
                        //         $transformed = [...$transformed, `$subkey as $subval`]
                        //     } }
                        // }
```