### PR TITLE
add `ensureNamespaceImportFrom`

### DIFF
--- a/.grit/patterns/common.grit
+++ b/.grit/patterns/common.grit
@@ -145,9 +145,9 @@ predicate AddImport($m, $fromArg) {
 
 predicate AddNamespaceImport($m, $fromArg) {
    $fromArg <: let($alias, $from) and {
-    or {
-      Identifier() as $alias,
-      $_ where $alias = Identifier(name = $m)
+    $_ where or {
+      $m <: Identifier() as $alias,
+      $alias = Identifier(name = $m)
     },
     or {
       StringLiteral() as $from,
@@ -155,11 +155,25 @@ predicate AddNamespaceImport($m, $fromArg) {
     }
   } where {
     $importDeclaration = ImportNamespaceSpecifier(local = $alias, id = null, name = null),
+    ! $importDeclaration <: $alreadySolved,
     $alreadySolved = or { $alreadySolved, $importDeclaration },
     $solvedPairs = or { $solvedPairs, `$importDeclaration, $from` },
     or { and { ! $from <: $froms, $froms = or { $froms, $from } }, true }
   }
 }
+
+predicate ensureNamespaceImportFrom($what, $from) {
+  or {
+    isNamespaceImported($what, $_),
+    AddNamespaceImport($what, $from)
+    true
+  }
+}
+
+predicate isNamespaceImported($name, $from) {
+    $program <: File(Program([..., ImportDeclaration(specifiers = some ImportNamespaceSpecifier(local = $name)) ,...]), $_)
+}
+
 
 predicate ReplaceImport($m, $from) {
   RemoveImport($m),
@@ -264,6 +278,7 @@ predicate InsertImports() {
 
 pattern PreludeRun() {
   $_ where {
+    $seen = or { },
     $alreadySolved = or { },
     $solvedPairs = or { },
     $froms = or { },

--- a/.grit/patterns/common.grit
+++ b/.grit/patterns/common.grit
@@ -163,10 +163,8 @@ predicate AddNamespaceImport($m, $fromArg) {
 }
 
 predicate ensureNamespaceImportFrom($what, $from) {
-  or {
-    isNamespaceImported($what, $_),
-    AddNamespaceImport($what, $from)
-    true
+  if (!isNamespaceImported($what, $_)) {
+    or { AddNamespaceImport($what, $from), true } // we don't have a maybe predicate
   }
 }
 


### PR DESCRIPTION
 - Adds `ensureNamespaceImportFrom`, which also avoids existing imports. 
 - Adds an `isNamespaceImported` predicate.
 - Adjusts `AddNamespaceImportFrom` to make it idempotent.
