### PR TITLE
migrate: `split_trpc_router`

### DIFF
--- a/.grit/patterns/split_trpc_router.md
+++ b/.grit/patterns/split_trpc_router.md
@@ -7,71 +7,93 @@ Split a tRPC router into multiple files, one per route.
 tags: #trpc, #router, #split, #typescript
 
 ```grit
+engine marzano(0.1)
 language js
 
-pattern NamedThing($name) {
-  or {
-    `const $name = $_`,
-    `function $name($_) { $_ }`
-  }
+pattern add_imports_and_refs($new_file_statements) {
+    foo()
 }
 
-Program(body=$body) where {
-    $body <: contains `t.router($_)`,
-    get_dirname($prefix),
-    // Look through every statement in the body (in its own scope, bubble creates scopes)
-    $body <: some bubble($imports, $refs, $middlewares, $prefix) or {
-        ImportDeclaration() as $import where {
-            $import => .,
-            append($imports, $import)
+pattern process_route($imports, $refs, $dir) {
+    pair($key, $value) where {
+        $route_name = `${key}Route`,
+        $value => `${route_name},`, // todo: drop comma after fixing bug
+        $file_name = `$dir/${key}.route.ts`,
+        $new_file_statements = [`import { proc } from "./middleware"`],
+        $imports <: maybe some filter_used_imports(local_imports = $new_file_statements, content = $value),
+
+        $refs <: maybe some bubble($value, $new_file_statements) named_thing($name) as $s where {
+            $value <: contains $name,
+            $new_file_statements += $s
         },
-        `export const $_ = t.router({$routes})` as $router where {
-            // Look at each route
-            $routes <: some bubble($imports, $refs, $prefix) `$key: $proc` => `$key: $routeName` where {
-                // Find only the top-level things referenced in this route to carry over
-                $refs <: maybe some bubble($ourRefs, $proc, $prefix) NamedThing($name) as $ref where {
-                    $proc <: contains $name,
-                    append($ourRefs, $ref)
-                },
 
-                $routeName = $key + "Route",
-                $newFileName = $key+".route",
-                $f = [
-                    // Insert the middleware
-                    `import { proc } from "./middleware"`,
-                    ...$ourRefs,
-                    `export const $routeName = $proc`
-                ],
-                $newImports = [],
-                $imports <: FilterUnusedImports($f, $newImports),
-                $newFile = [...$newImports, $f],
-                $newFiles = [ File(name = $prefix + $newFileName + ".ts", program = Program($newFile)) ],
+        $new_file_statements += `export ${route_name} = $value`,
 
-                $relativeFilename = "./" + $newFileName,
-                ensureImportFrom(Identifier(name=$routeName), `$relativeFilename`)
+        $separator = `;\n`,
+        $body = join(list = $new_file_statements, $separator),
+        $new_files += file(name = $file_name, $body)
+    }
+}
+
+pattern filter_used_imports($local_imports, $content) {
+    import_statement($source) as $import where {
+        $used_list = [],
+        $import <: contains bubble($used_list, $content) or {
+            import_specifier($name),
+            namespace_import(namespace = $name) 
+        } as $i where {
+            $content <: contains $name,
+            $used_list += $i
+        },
+        $separator = `, `,
+        $used = join(list = $used_list, $separator),
+        $local_imports += `import { $used } from $source`
+    }
+}
+
+pattern named_thing($name) {
+    or {
+        lexical_declaration(declarations = [variable_declarator($name, $value)]),
+        function_declaration($name)
+    }
+}
+
+pattern process_one_statement($imports, $middlewares, $refs, $dir) {
+    or {
+        import_statement() as $import where {
+            $import => .,
+            $imports += $import
+        },
+        export_statement(declaration = lexical_declaration(declarations = [variable_declarator($name, $value)])) as $s where or {
+            and {
+                $value <: `t.router($routes_object)`,
+                $routes_object <: object($properties),
+                $properties <: some process_route($imports, $refs, $dir) // todo: drop comma after fixing bug
+            },
+            and {
+                $middlewares += $s,
+                $s => .
             }
         },
-        // Grab middlewares
-        `export const t = $_` as $t => . where { append($middlewares, $t) },
-        `const $name = $thing` => . where {
-            $thing <: or {
-                `t.middleware($_)`,
-                `t.procedure.use($_)`
-            },
-            $export = `export const $name = $thing`,
-            append($middlewares, $export)
+        lexical_declaration(declarations = [variable_declarator($value)]) as $s => . where {
+            $value <: or { `t.middleware($_)`, `t.procedure.use($_)` },
+            $middlewares += `export $s`
         },
-        // Gather all other global functions/conts
-        NamedThing($_) as $ref => . where { append($refs, $ref) }
-    },
-    // Put all the middleware in a new file
-    $middlewareImports = [],
-    $imports <: FilterUnusedImports($middlewares, $middlewareImports),
-    $newFiles = [...$newFiles, File(name=$prefix + "middleware.ts", program=Program([
-      ...$middlewareImports, ...$middlewares
-    ]))],
-
-    ensureImportFrom(`t`, "./middleware")
+        named_thing($_) as $s => . where $refs += $s
+    }
+}
+ 
+file($name, body = program($statements)) where {
+    $name <: r"(.*)/[^/]*"($dir),
+    $statements <: contains `t.router($_)`,
+    $imports = [],
+    $middlewares = [],
+    $refs = [],
+    $statements <: some process_one_statement($imports, $middlewares, $refs, $dir),
+    $separator = `;\n`,
+    $middleware_body = join(list = $middlewares, $separator),
+    $middleware_file = `$dir/middleware.ts`,
+    $new_files += file(name = $middleware_file, body = $middleware_body)
 }
 ```
 

--- a/.grit/patterns/split_trpc_router.md
+++ b/.grit/patterns/split_trpc_router.md
@@ -10,10 +10,6 @@ tags: #trpc, #router, #split, #typescript
 engine marzano(0.1)
 language js
 
-pattern add_imports_and_refs($new_file_statements) {
-    foo()
-}
-
 pattern process_route($imports, $refs, $dir) {
     pair($key, $value) where {
         $route_name = `${key}Route`,
@@ -53,7 +49,7 @@ pattern filter_used_imports($local_imports, $content) {
 
 pattern named_thing($name) {
     or {
-        lexical_declaration(declarations = [variable_declarator($name, $value)]),
+        lexical_declaration(declarations = [variable_declarator($name)]),
         function_declaration($name)
     }
 }


### PR DESCRIPTION
`grit patterns test` does not pass, and it did not in the previous version either -- I guess because it would require multi-output support.

![Screenshot 2023-06-14 at 5 08 36 PM](https://github.com/getgrit/js/assets/37514/e649372e-a10b-47ed-b28c-9f60d791b73f)
