### PR TITLE
chore: try switching to namespace cloud runners

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,10 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
+        runner: [ubuntu-22.04, nscloud-ubuntu-22.04-amd64-4x16]
         node-version: [16.16, 18.x, 20.x]
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,31 +5,31 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16
 
     strategy:
       matrix:
-        node-version: [16.16,18.x,20.x]
+        node-version: [16.16, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Install @getgrit/launcher
-      run: npm install -g @getgrit/launcher
+      - name: Install @getgrit/launcher
+        run: npm install -g @getgrit/launcher
 
-    - name: Run doctor
-      run: npx grit doctor
+      - name: Run doctor
+        run: npx grit doctor
 
-    - name: Run grit patterns test
-      run: npx grit patterns test
+      - name: Run grit patterns test
+        run: npx grit patterns test


### PR DESCRIPTION
GitHub Actions has been rather flaky recently and [Namespace](https://namespace.so/) looks like a good alternative to try for both CI and, eventually, VM execution. Adding it as an option in the matrix for evaluation.