### PR TITLE
chore: match routes_object against a list

### DIFF
--- a/.grit/patterns/split_trpc_router.md
+++ b/.grit/patterns/split_trpc_router.md
@@ -73,7 +73,7 @@ pattern process_one_statement($imports, $middlewares, $refs, $dir, $main_file_im
         export_statement(declaration = lexical_declaration(declarations = [variable_declarator($name, $value)])) as $s where or {
             and {
                 $value <: `t.router($routes_object)`,
-                $routes_object <: object($properties),
+                $routes_object <: [object($properties)],
                 $properties <: some process_route($imports, $refs, $dir, $main_file_imports) // todo: drop comma after fixing bug
             },
             and {


### PR DESCRIPTION
update required for https://github.com/getgrit/rewriter/pull/5084, without that pr this will break the pattern. 