### PR TITLE
chore: migrate `no_async_promise_executor`

### DIFF
--- a/.grit/patterns/no_async_promise_executor.md
+++ b/.grit/patterns/no_async_promise_executor.md
@@ -11,14 +11,17 @@ Creating an Promise from an async function is [usually an error](https://eslint.
 tags: #fix, #bug
 
 ```grit
+engine marzano(0.1)
+language js
+
 or {
   `new Promise($promise)` where {
-    $promise <: contains { `async $args => $body` => `$args => $body`},
-    $body <: not contains { AwaitExpression() }
+    $promise <: contains { `async ($args) => $body` => `($args) => $body`},
+    $body <: not contains await_expression()
   },
 
   `new Promise(async ($resolve, $reject) => $body)` => `(async () => $body)()` where {
-    $body <: contains { AwaitExpression() },
+    $body <: contains { await_expression() },
     $body <: contains bubble or { `resolve($a)` =>  `return $a;` , `reject($a)`  =>  `throw $a;` }
   }
 }


### PR DESCRIPTION
fixes https://github.com/getgrit/rewriter/issues/5299