### PR TITLE
feat: add Jest to AVA pattern

### DIFF
--- a/.grit/patterns/jest_to_ava.grit
+++ b/.grit/patterns/jest_to_ava.grit
@@ -1,0 +1,119 @@
+engine marzano(0.1)
+language js
+
+pattern expect_is($actual) {
+    or {
+       `expect($actual)` => `t.is`,
+       `expect($actual).not` => `t.not`,
+    }
+}
+
+pattern expect_not($actual) {
+    or {
+       `expect($actual)` => `t.not`,
+       `expect($actual).not` => `t.is`,
+    }
+}
+
+pattern expect_true($actual) {
+    or {
+       `expect($actual)` => `t.true`,
+       `expect($actual).not` => `t.false`,
+    }
+}
+
+// TODO: Compose with `expect_{is, not, true}`?
+pattern expect_resolves($actual, $expected) {
+    or {
+        `expect($actual)` => `t.is($actual, $expected)`,
+        `expect($actual).resolves` => `$actual.then(result => t.is(result, $expected))`,
+    }
+}
+
+or {
+    `test($name, () => {$body})` => `test($name, t => {\n  $body})`,
+
+    `expect($actual).toEqual($expected)` => `t.deepEqual($actual, $expected)`,
+    `expect($actual).not.toEqual($expected)` => `t.notDeepEqual($actual, $expected)`,
+    `expect($actual).toBe($expected)` => `t.is($actual, $expected)`,
+    `expect($actual).not.toBe($expected)` => `t.not($actual, $expected)`,
+    `expect($actual).toBeTruthy()` => `t.truthy($actual)`,
+    `expect($actual).not.toBeTruthy()` => `t.falsy($actual)`,
+    `expect($actual).toBeFalsy()` => `t.falsy($actual)`,
+    `expect($actual).not.toBeFalsy()` => `t.truthy($actual)`,
+    `expect($fn).toThrow($expected)` => `t.throws($fn, $expected)`,
+    `expect($promise).rejects.toThrow($expected)` => `t.throwsAsync($promise, $expected)`,
+    `expect($fn).not.toThrow($expected)` => `t.notThrows($fn, $expected)`,
+    `expect($promise).not.rejects.toThrow($expected)` => `t.notThrowsAsync($promise, $expected)`,
+
+    // TODO: Handle .resolves, .rejects in a generic way
+    `$expect.toHaveLength($length)` where { $expect <: expect_is($actual) } => `$expect($actual.length, $length)`,
+    `$expect.toBeCloseTo($expected, $numDigits)` where { $expect <: expect_true($actual) } => `$expect(Math.abs($actual - $expected) < 10 ** -$numDigits / 2)`,
+    `$expect.toBeCloseTo($args)` where { $expect <: expect_true($actual), $args <: [$expected] } => `$expect(Math.abs($actual - $expected) < 0.005)`, 
+    `$expect.toBeDefined()` where { $expect <: expect_not($actual) } => `$expect($actual, undefined)`,
+    `$expect.toBeGreaterThan($number)` where { $expect <: expect_true($actual) } => `$expect($actual > $number)`,
+    `$expect.toBeGreaterThanOrEqual($number)` where { $expect <: expect_true($actual) } => `$expect($actual >= $number)`,
+    `$expect.toBeLessThan($number)` where { $expect <: expect_true($actual) } => `$expect($actual < $number)`,
+    `$expect.toBeLessThanOrEqual($number)` where { $expect <: expect_true($actual) } => `$expect($actual <= $number)`,
+    `$expect.toBeInstanceOf($class)` where { $expect <: expect_true($instance) } => `$expect($instance instanceof $class)`,
+    `$expect.toBeNull()` where { $expect <: expect_is($actual) } => `$expect($actual, null)`,
+    `$expect.toBeUndefined()` where { $expect <: expect_is($actual) } => `$expect($actual, undefined)`,
+    `$expect.toBeNaN()` where { $expect <: expect_is($actual) } => `$expect($actual, NaN)`,
+    `$expect.toMatch($string)` where { $expect <: expect_is($actual) } => `$expect($actual, $string)` where { $string <: string() },
+    `expect($actual).toMatch($regex)` => `t.regex($actual, $regex)` where { $regex <: regex() },
+    `expect($actual).toMatch($regex)` => `t.regex($actual, $regex)`, // Fallback due to lack of `semantic`
+
+    //
+    // TODO: Everything below
+    //
+
+    // Requires mocking library like Sinon.js
+    `expect($actual).toHaveBeenCalled()` => ``,
+    `expect($actual).toHaveBeenCalledTimes($number)` => ``,
+    `expect($actual).toHaveBeenCalledWith($args)` => ``,
+    `expect($actual).toHaveBeenLastCalledWith($args)` => ``,
+    `expect($actual).toHaveBeenNthCalledWith($nth, $arg0, $arg1, $arg2)` => ``,
+    `expect($actual).toHaveReturned()` => ``,
+    `expect($actual).toHaveReturnedTimes($number)` => ``,
+    `expect($actual).toHaveReturnedWith($value)` => ``,
+    `expect($actual).toHaveLastReturnedWith($value)` => ``,
+    `expect($actual).toHaveNthReturnedWith($nthCall, $value)` => ``,
+
+    // Requires path selection logic
+    `expect($actual).toHaveProperty($keyPath, $value)` => ``,
+
+	// === on array items, or substring on string
+    `expect($actual).toContain($item)` => ``,
+
+	// deepEqual on array items
+    `expect($actual).toContainEqual($item)` => ``,
+
+    `expect($actual).toMatchObject($object)` => ``,
+    `expect($actual).toMatchSnapshot($propertyMatchers, $hint)` => ``,
+    `expect($actual).toMatchInlineSnapshot($propertyMatchers, $inlineSnapshot)` => ``,
+
+    // TODO: Check Ava.js / Concordance behavior
+    `expect($actual).toStrictEqual($value)` => ``,
+
+    `expect($actual).toThrowErrorMatchingSnapshot($hint)` => ``,
+    `expect($actual).toThrowErrorMatchingInlineSnapshot($inlineSnapshot)` => ``,
+
+    `expect.anything()` => ``,
+    `expect.any($constructor)` => ``,
+    `expect.arrayContaining($array)` => ``,
+    `expect.not.arrayContaining($array)` => ``,
+    `expect.closeTo($number)` => ``,
+    `expect.closeTo($number, $numDigits)` => ``,
+    `expect.objectContaining($object)` => ``,
+    `expect.not.objectContaining($object)` => ``,
+    `expect.stringContaining($object)` => ``,
+    `expect.not.stringContaining($object)` => ``,
+    `expect.stringMatching($stringOrRegexp)` => ``,
+    `expect.not.stringMatching($stringOrRegexp)` => ``,
+
+	`expect.assertions($number)` => ``,
+	`expect.hasAssertions()` => ``,
+	`expect.addEqualityTesters($testers)` => ``,
+	`expect.addSnapshotSerializer($serializer)` => ``,
+	`expect.extend($matchers)` => ``,
+}


### PR DESCRIPTION
Work-in-progress pattern for converting Jest tests to AVA tests.

Minimal test case:

```js
test('test name', () => {
  const actual = { value: 3 }
  expect(actual).toEqual({ value: 3 })
  expect(actual).not.toEqual({ value: 4 })

  const ref1 = { singleton: true }
  const ref2 = ref1
  expect(ref1).toBe(ref2)
  expect(ref1).not.toBe({ singleton: true })

  expect([0, 1, 2]).toHaveLength(3)
  expect([0, 1, 2]).not.toHaveLength(4)

  expect(Math.PI).toBeCloseTo(3.14, 5)
  expect(Math.PI).not.toBeCloseTo(3.14, 5)
  expect(Math.PI).toBeCloseTo(3.14)
  expect(Math.PI).not.toBeCloseTo(3.14)

  const testRegex = /123?/
  expect('12').toMatch(testRegex)
  expect('ab').toMatch(/abc?/)
  expect('xyz').toMatch('xyz')
})
```

Should result in:

```js
test('test name', t => {
  const actual = { value: 3 }
  t.deepEqual(actual, { value: 3 })
  t.notDeepEqual(actual, { value: 4 })

  const ref1 = { singleton: true }
  const ref2 = ref1
  t.is(ref1, ref2)
  t.not(ref1, { singleton: true })

  t.is([0, 1, 2].length, 3)
  t.not([0, 1, 2].length, 4)

  t.true(Math.abs(Math.PI - 3.14) < 10 ** -5 / 2)
  t.false(Math.abs(Math.PI - 3.14) < 10 ** -5 / 2)
  t.true(Math.abs(Math.PI - 3.14) < 0.005)
  t.false(Math.abs(Math.PI - 3.14) < 0.005)

  const testRegex = /123?/
  t.regex('12', testRegex)
  t.regex('ab', /abc?/)
  t.is('xyz', 'xyz')})
  ```