### PR TITLE
fix: use any instead of maybe

### DIFF
--- a/.grit/patterns/openai_v4.md
+++ b/.grit/patterns/openai_v4.md
@@ -112,12 +112,12 @@ pattern change_completion_try_catch() {
     }
 }
 
-program($statements) where $statements <: and {
-    maybe contains bubble change_constructor(),
-    maybe contains bubble change_chat_completion(),
-    maybe contains bubble change_completion(),
-    maybe contains bubble change_transcription(),
-    maybe contains bubble change_completion_try_catch()
+program($statements) where $statements <: any {
+    contains bubble change_constructor(),
+    contains bubble change_chat_completion(),
+    contains bubble change_completion(),
+    contains bubble change_transcription(),
+    contains bubble change_completion_try_catch()
 }
 ```
 

--- a/.grit/patterns/openai_v4.md
+++ b/.grit/patterns/openai_v4.md
@@ -112,12 +112,15 @@ pattern change_completion_try_catch() {
     }
 }
 
-program($statements) where $statements <: any {
+program($statements) where $statements <: and {
+  or { includes "openai", includes "createCompletion", includes "OpenAIAPI", includes "createTranscription" },
+  any {
     contains bubble change_constructor(),
     contains bubble change_chat_completion(),
     contains bubble change_completion(),
     contains bubble change_transcription(),
     contains bubble change_completion_try_catch()
+  }
 }
 ```
 


### PR DESCRIPTION
Including the early includes check is a massive performance boost:
```
# with
time gritdev apply openai_v4 packages/universal
Processed 32 files and found 0 matches
/Users/morgante/code/grit/rewriter/target/release/marzano apply openai_v4   0.80s user 0.05s system 84% cpu 0.999 total
# without
 ~/code/grit/rewriter   main  time gritdev apply openai_v4 packages/universal
Processed 32 files and found 0 matches
/Users/morgante/code/grit/rewriter/target/release/marzano apply openai_v4   16.35s user 0.21s system 97% cpu 16.902 total
```