### PR TITLE
fix: insert imports after shebang

### DIFF
--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -53,6 +53,7 @@ fetch();
 import fetch from 'elsewhere';
 
 import { more } from 'node-fetch';
+
 import { orderBy } from 'lodash';
 import { v4 } from 'uuid';
 
@@ -62,6 +63,41 @@ console.log(orderBy([1, 2, 3]));
 console.log(v4());
 
 fetch();
+```
+
+## Ignores Shebang
+```js
+#!/usr/bin/env node
+
+import { orderBy } from 'underscore';
+import fetch from 'elsewhere';
+import { fetch } from 'node-fetch';
+import { fetch, more } from 'node-fetch';
+import fetch from 'node-fetch';
+
+console.log(orderBy([1, 2, 3]));
+
+console.log(v4());
+
+fetch()
+```
+
+```js
+#!/usr/bin/env node
+
+import fetch from 'elsewhere';
+
+import { more } from 'node-fetch';
+
+import { orderBy } from 'lodash';
+import { v4 } from 'uuid';
+
+
+console.log(orderBy([1, 2, 3]));
+
+console.log(v4());
+
+fetch()
 ```
 
 ## Ensures a React import

--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -50,13 +50,12 @@ fetch();
 ```
 
 ```js
-import fetch from 'elsewhere';
-
-import { more } from 'node-fetch';
-
 import { orderBy } from 'lodash';
 import { v4 } from 'uuid';
 
+import fetch from 'elsewhere';
+
+import { more } from 'node-fetch';
 
 console.log(orderBy([1, 2, 3]));
 
@@ -84,14 +83,12 @@ fetch()
 
 ```js
 #!/usr/bin/env node
+import { orderBy } from 'lodash';
+import { v4 } from 'uuid';
 
 import fetch from 'elsewhere';
 
 import { more } from 'node-fetch';
-
-import { orderBy } from 'lodash';
-import { v4 } from 'uuid';
-
 
 console.log(orderBy([1, 2, 3]));
 

--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -50,12 +50,12 @@ fetch();
 ```
 
 ```js
-import { orderBy } from 'lodash';
-import { v4 } from 'uuid';
-
 import fetch from 'elsewhere';
 
 import { more } from 'node-fetch';
+import { orderBy } from 'lodash';
+import { v4 } from 'uuid';
+
 
 console.log(orderBy([1, 2, 3]));
 

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -71,7 +71,8 @@ pattern insert_imports() {
             $last = "",
             $p <: maybe contains bubble($last) last_import($last),
             if ($last <: not .) {
-                $last => `$last\n$all_imports`,
+                $p <: contains $first where { $first <: after $last },
+                $first => `$all_imports\n\n$first`,
             } else {
                 $p => `$all_imports\n$p`
             }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -55,16 +55,30 @@ pattern process_one_source($p, $all_imports) {
     }
 }
 
+pattern last_import($last) {
+    or { 
+        `import $im_name from '$im_source';`,
+        r"^#!(.*)"($shebang) } as $curr where {
+        $last = $curr
+    },
+}
+
 pattern insert_imports() {
     $p where {
         $all_imports = [],
         $GLOBAL_IMPORTED_SOURCES <: some process_one_source($p, $all_imports),
         if ($all_imports <: not []) {
-            $p => `$all_imports\n$p`
+            $last = "",
+            $p <: maybe contains bubble($last) last_import($last),
+            if ($last <: not .) {
+                $last => `$last\n$all_imports`,
+            } else {
+                $p => `$all_imports\n$p`
+            }
         } else {
             true
         }
-    }
+    },
 }
 
 pattern after_each_file_handle_imports() {

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -79,7 +79,7 @@ pattern insert_imports() {
         } else {
             true
         }
-    },
+    }
 }
 
 pattern after_each_file_handle_imports() {

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -55,24 +55,21 @@ pattern process_one_source($p, $all_imports) {
     }
 }
 
-pattern last_import($last) {
-    or { 
-        `import $im_name from '$im_source';`,
-        r"^#!(.*)"($shebang) } as $curr where {
-        $last = $curr
-    },
+pattern get_shebang($shebang) {
+    r"^#!(.*)"($sb) as $curr where {
+        $shebang = $curr
+    }
 }
 
 pattern insert_imports() {
     $p where {
         $all_imports = [],
+        $shebang = "",
         $GLOBAL_IMPORTED_SOURCES <: some process_one_source($p, $all_imports),
         if ($all_imports <: not []) {
-            $last = "",
-            $p <: maybe contains bubble($last) last_import($last),
-            if ($last <: not .) {
-                $p <: contains $first where { $first <: after $last },
-                $first => `$all_imports\n\n$first`,
+            $p <: maybe contains bubble($shebang) get_shebang($shebang),
+            if ($shebang <: not .) {
+                $shebang => `$shebang\n$all_imports`,
             } else {
                 $p => `$all_imports\n$p`
             }


### PR DESCRIPTION
Imports location is put in the following priority:

- Below the shebang
- At the top of the file

Fixes #188

