### PR TITLE
chore: hide patterns we use in workflows

### DIFF
--- a/.grit/patterns/enzyme_rtl.md
+++ b/.grit/patterns/enzyme_rtl.md
@@ -4,7 +4,9 @@ title: Enzyme to React Testing Library
 
 (Alpha) This pattern is a work in progress and is not yet ready for use.
 
-tags: #enzyme, #react-testing-library, #rtl, #alpha, #migration
+Note: the full migration is packaged as a workflow. This is just a subcomponent.
+
+tags: #enzyme, #react-testing-library, #rtl, #alpha, #migration, #hidden
 
 ```grit
 predicate rtl_import_render() {

--- a/.grit/patterns/serverless_to_spin.md
+++ b/.grit/patterns/serverless_to_spin.md
@@ -4,7 +4,9 @@ title: Convert AWS Lambda Functions to Fermyon Spin
 
 This pattern converts a serverless function to a spin function designed to run on [Fermyon](https://www.fermyon.com/).
 
-tags: #js, #migration, #serverless, #fermyon, #alpha
+Note: the full migration is packaged as a workflow. This is just a subcomponent.
+
+tags: #js, #serverless, #fermyon, #alpha, #hidden
 
 ```grit
 engine marzano(0.1)


### PR DESCRIPTION
It is confusing to show both in the UI.