### PR TITLE
fix: `remove_import(mymodule)` pattern to not delete the whole line when given `import defaultExport, {myModule}`

### DIFF
--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -43,6 +43,7 @@ import fetch from 'elsewhere';
 import { fetch } from 'node-fetch';
 import { fetch, more } from 'node-fetch';
 import fetch from 'node-fetch';
+import defaultNotNamedFetch, { fetch } from 'node-fetch';
 
 console.log(orderBy([1, 2, 3]));
 
@@ -59,6 +60,7 @@ import { v4 } from 'uuid';
 import fetch from 'elsewhere';
 
 import { more } from 'node-fetch';
+import defaultNotNamedFetch from 'node-fetch';
 
 console.log(orderBy([1, 2, 3]));
 

--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -60,6 +60,7 @@ import { v4 } from 'uuid';
 import fetch from 'elsewhere';
 
 import { more } from 'node-fetch';
+
 import defaultNotNamedFetch from 'node-fetch';
 
 console.log(orderBy([1, 2, 3]));

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -94,10 +94,13 @@ pattern remove_import($from) {
                 $import => .
             },
             // Handle named import
-            import_clause(name = named_imports($imports) as $import_list_with_braces) where {
+            import_clause(default=$default_export, name=named_imports($imports) as $import_list_with_braces) where {
                 $others = `false`,
-                if ($imports <: [$name]) {
-                    $import_list_with_braces => .
+                if (and {
+                    $imports <: [$name] ,
+                    !$default_export <: .
+                    }) {
+                        $import_list_with_braces => .
                 } else {
                     $imports <: some $name => .
                 }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -94,13 +94,13 @@ pattern remove_import($from) {
                 $import => .
             },
             // Handle named import
-            import_clause(default=$default_export, name=named_imports($imports) as $import_list_with_braces) where {
+            import_clause(default=$default_export, name=named_imports($imports)) as $clause where {
                 $others = `false`,
                 if (and {
                     $imports <: [$name] ,
                     !$default_export <: .
                     }) {
-                        $import_list_with_braces => .
+                        $clause => `$default_export`
                 } else {
                     $imports <: some $name => .
                 }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -94,10 +94,10 @@ pattern remove_import($from) {
                 $import => .
             },
             // Handle named import
-            import_clause(name = named_imports($imports)) where {
+            import_clause(name = named_imports($imports) as $import_list_with_braces) where {
                 $others = `false`,
                 if ($imports <: [$name]) {
-                    $import => .
+                    $import_list_with_braces => .
                 } else {
                     $imports <: some $name => .
                 }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -96,11 +96,12 @@ pattern remove_import($from) {
             // Handle named import
             import_clause(default=$default_export, name=named_imports($imports)) as $clause where {
                 $others = `false`,
-                if (and {
-                    $imports <: [$name] ,
-                    !$default_export <: .
-                    }) {
+                if ($imports <: [$name]) {
+                    if ($default_export <: .) {
+                        $import => .
+                    } else {
                         $clause => $default_export
+                    }
                 } else {
                     $imports <: some $name => .
                 }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -100,7 +100,7 @@ pattern remove_import($from) {
                     $imports <: [$name] ,
                     !$default_export <: .
                     }) {
-                        $clause => `$default_export`
+                        $clause => $default_export
                 } else {
                     $imports <: some $name => .
                 }

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -94,13 +94,13 @@ pattern remove_import($from) {
                 $import => .
             },
             // Handle named import
-            import_clause(default=$default_export, name=named_imports($imports)) as $clause where {
+            import_clause($default, name=named_imports($imports)) as $clause where {
                 $others = `false`,
                 if ($imports <: [$name]) {
-                    if ($default_export <: .) {
+                    if ($default <: .) {
                         $import => .
                     } else {
-                        $clause => $default_export
+                        $clause => $default
                     }
                 } else {
                     $imports <: some $name => .


### PR DESCRIPTION
Currently, if you use `remove_import(moduleToRemove)` on this line of Javascript:

```javascript
import myDefaultExport, { moduleToRemove } from "pkg";
```
Grit will delete the whole line instead of returning

```javascript
import myDefaultExport from "pkg";
```

This PR attempts to fix the bug such that only the named import list gets removed. The existing path in `remove_import` is:

```
  // Handle named import
            import_clause(name = named_imports($imports)) where {
                $others = `false`,
                if ($imports <: [$name]) {
                    $import => .
                } else { ... }
            }
```

The idea of this PR is to change the case where `imports` is a list with just the module to remove from removing the whole line.
Instead, we check if we have a non-empty default export with `default=$default_export` + `!$default_export <: .`, and if so, we replace the whole `import_clause` with just the name of the default export.

A previous attempt had tried to reset just the `named_imports` attribute of the `import_clause` AST node but that resulted in having a trailing coma.

This turns into:
```
 // Handle named import
     import_clause(default=$default_export, name=named_imports($imports)) as $clause where {
                $others = `false`,
                if (and {
                    $imports <: [$name] ,
                    !$default_export <: .
                    }) {
                        $clause => `$default_export`
                } else { ... }
 ...

We cannot simply empty `imports` because it results in an invalid AST node being created and deleting the whole line.