### PR TITLE
chore: snippets aren't strings

### DIFF
--- a/.grit/patterns/importing.md
+++ b/.grit/patterns/importing.md
@@ -23,12 +23,9 @@ contains or {
       $fetch <: remove_import($from)
   },
   `class $_ extends $comp { $_ }` where {
-    $comp <: `Component`,
+    $comp <: "Component",
     $source = `"React"`,
     $comp <: ensure_import_from($source),
-    // This is just a test of bindings
-    $thing = `Button`,
-    $thing <: `Button`
   }
 }
 ```

--- a/.grit/patterns/imports.grit
+++ b/.grit/patterns/imports.grit
@@ -95,7 +95,6 @@ pattern remove_import($from) {
             },
             // Handle named import
             import_clause($default, name=named_imports($imports)) as $clause where {
-                $others = `false`,
                 if ($imports <: [$name]) {
                     if ($default <: .) {
                         $import => .


### PR DESCRIPTION
required for yaml equivalence classes